### PR TITLE
Fix use of propertynames with SeisDicts

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -97,7 +97,7 @@ Base.setproperty!(sd::SeisDict{K,V}, key::Symbol, ::Missing) where {K,V} = delet
 Base.setproperty!(sd::SeisDict{K,Any}, key::Symbol, ::Missing) where K = delete!(sd, key)
 Base.setproperty!(sd::SeisDict{K,V}, key::Symbol, val) where {K,V} = setindex!(sd, V(val), key)
 Base.setproperty!(sd::SeisDict{K,Any}, key::Symbol, val) where K = setindex!(sd, val, key)
-Base.propertynames(sd::SeisDict, private=false) = collect(keys(sd))
+Base.propertynames(sd::SeisDict, private::Bool=false) = collect(keys(sd))
 
 Base.getproperty(sd::AbstractArray{<:SeisDict}, key::Symbol) = getproperty.(sd, key)
 Base.setproperty!(sd::AbstractArray{<:SeisDict}, key::Symbol, val) = setproperty!.(sd, key, val)

--- a/test/types.jl
+++ b/test/types.jl
@@ -7,14 +7,20 @@ using Seis
         @testset "Single dicts" begin
             d = Seis.SeisDict(:a=>1)
             @test d[:a] == 1
+            @test haskey(d, :a) == true
+            @test hasproperty(d, :a) == true
+            @test propertynames(d) == [:a]
             @test d.a == 1
             @test d.b === missing
+            @test hasproperty(d, :b) == false
             d.b = 2
             @test d[:b] == d.b == 2
+            @test propertynames(d) == [:a, :b]
             d.a = d.b = missing
             @test haskey(d, :a) == false
             @test haskey(d, :b) == false
             @test collect(keys(d)) == []
+            @test hasproperty(d, :a) == false
         end
         
         @testset "Arrays" begin

--- a/test/types.jl
+++ b/test/types.jl
@@ -2,6 +2,10 @@ using Test
 using Dates
 using Seis
 
+@static if VERSION < v"1.2"
+    hasproperty(d, k) = k in propertynames(d)
+end
+
 @testset "Types" begin
     @testset "SeisDict" begin
         @testset "Single dicts" begin


### PR DESCRIPTION
Previously there was a method ambiguity.  Fix this by
stating that the `private` argument to `propertynames`
must be a `Bool`.

Add tests for `propertynames` and `hasproperty`.
