### PR TITLE
CI: Try to fix quoting on Windows

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -41,8 +41,14 @@ jobs:
             ${{ runner.os }}-test-${{ env.cache-name }}-
             ${{ runner.os }}-test-
             ${{ runner.os }}-
-      - name: Install unregistered dependencies
+      - name: Install unregistered dependencies (Unix)
+        if: ${{ matrix.os != 'windows-latest' }}
         run: julia --project -e 'using Pkg; Pkg.add(PackageSpec(url="https://github.com/anowacki/Geodesics.jl"))'
+      # Work around problems with quoting when using PowerShell on Windows by using cmd.exe
+      - name: Install unregistered dependencies (Windows)
+        if: ${{ matrix.os == 'windows-latest' }}
+        run: julia --project -e "using Pkg; Pkg.add(PackageSpec(url=\"https://github.com/anowacki/Geodesics.jl\"))"
+        shell: cmd
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1
@@ -52,6 +58,7 @@ jobs:
 
   docs:
     name: Documentation
+    needs: test
     runs-on: ubuntu-latest
     env:
       GKSwstype: nul


### PR DESCRIPTION
On Windows,  leads to Julia throwing
a syntax error because  is not a unary operator, suggesting
the double quotes are not being seen by the Julia process when
passing the string to the  option.  Try to quote the
argument differently so it works on Windows and Unixy OSes.
