### PR TITLE
More comprehensive and correct rotations

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,7 @@ jobs:
         shell: cmd
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
+        continue-on-error: ${{ matrix.version == 'nightly' }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
         with:

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@
   not just horizontal ones.
 - `rotate_to_lqt[!]` rotates triplets of orthogonal components to
   LQT orientation.
-- `rotate_to_azimuth_incidence!` rotates triplets of orthogonal components
+- `rotate_to_azimuth_incidence[!]` rotates triplets of orthogonal components
   to arbitrary orientations.
 
 ## Deprecated or removed

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,11 @@
 - `rotate_to_azimuth_incidence!` rotates triplets of orthogonal components
   to arbitrary orientations.
 
+## Deprecated or removed
+- `traces_are_orthogonal` will be removed in v0.5.  It has been replaced by
+  `are_orthogonal` which works for non-horizontal pairs.
+
+
 ## Notable bug fixes
 - `rotate_through[!]` behaved in an inconsistent way and has been fixed
   (see 'Breaking changes'), but its new behaviour is different.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,0 +1,19 @@
+# Seis.jl v0.4 release notes
+
+## Breaking changes
+- `rotate_through[!]` now explicitly implements the partial de-facto
+  previous behaviour: that the direction of the rotation is defined
+  by the order of the traces.
+  **Versions of this function prior to this change may have got the
+  sense of the rotation wrong and defined the trace azimuths wrong**
+  depending on the trace input order,
+  and so this is technically a breaking change.  However the new
+  behaviour is correct, so can now be relied upon.
+
+## New features
+- `rotate_through[!]` can rotate arbitrary pairs of orthogonal traces,
+  not just horizontal ones.
+
+## Notable bug fixes
+- `rotate_through[!]` behaved in an inconsistent way and has been fixed
+  (see 'Breaking changes'), but its new behavious is different.

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,11 @@
 ## New features
 - `rotate_through[!]` can rotate arbitrary pairs of orthogonal traces,
   not just horizontal ones.
+- `rotate_to_lqt[!]` rotates triplets of orthogonal components to
+  LQT orientation.
+- `rotate_to_azimuth_incidence!` rotates triplets of orthogonal components
+  to arbitrary orientations.
 
 ## Notable bug fixes
 - `rotate_through[!]` behaved in an inconsistent way and has been fixed
-  (see 'Breaking changes'), but its new behavious is different.
+  (see 'Breaking changes'), but its new behaviour is different.

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,6 +13,8 @@
 ## New features
 - `rotate_through[!]` can rotate arbitrary pairs of orthogonal traces,
   not just horizontal ones.
+- `rotate_to_enz[!]` rotates triplets of orthogonal components to ENZ
+  orientation
 - `rotate_to_lqt[!]` rotates triplets of orthogonal components to
   LQT orientation.
 - `rotate_to_azimuth_incidence[!]` rotates triplets of orthogonal components
@@ -20,7 +22,7 @@
 
 ## Deprecated or removed
 - `traces_are_orthogonal` will be removed in v0.5.  It has been replaced by
-  `are_orthogonal` which works for non-horizontal pairs.
+  `are_orthogonal` which works for non-horizontal pairs as well.
 
 
 ## Notable bug fixes

--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,7 @@ Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 RecipesBase = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 SeisIO = "b372bb87-02dd-52bb-bcf6-c30dd83fd342"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
@@ -18,10 +19,12 @@ DSP = "0.6, 0.7"
 Glob = "1"
 RecipesBase = "1"
 SeisIO = "1"
+StaticArrays = "1"
 julia = "1"
 
 [extras]
+Rotations = "6038ab10-8711-5258-84ad-4b1120ba62dc"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Rotations", "Test"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -1,19 +1,25 @@
 # This file is machine-generated - editing it directly is not advised
 
+[[ANSIColoredPrinters]]
+git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
+uuid = "a4c015fc-c6ff-483c-b24f-f7ea428134e9"
+version = "0.0.1"
+
 [[AbstractFFTs]]
-deps = ["LinearAlgebra"]
-git-tree-sha1 = "485ee0867925449198280d4af84bdb46a2a404d0"
+deps = ["ChainRulesCore", "LinearAlgebra"]
+git-tree-sha1 = "6f1d9bc1c08f9f4a8fa92e3ea3cb50153a1b40d4"
 uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
-version = "1.0.1"
+version = "1.1.0"
 
 [[Adapt]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "84918055d15b3114ede17ac6a7182f68870c16f7"
+git-tree-sha1 = "af92965fb30777147966f58acb05da51c5616b5f"
 uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
-version = "3.3.1"
+version = "3.3.3"
 
 [[ArgTools]]
 uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
 
 [[Artifacts]]
 uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -29,39 +35,45 @@ version = "0.5.10"
 
 [[Blosc]]
 deps = ["Blosc_jll"]
-git-tree-sha1 = "84cf7d0f8fd46ca6f1b3e0305b4b4a37afe50fd6"
+git-tree-sha1 = "310b77648d38c223d947ff3f50f511d08690b8d5"
 uuid = "a74b3585-a348-5f62-a45c-50e91977d574"
-version = "0.7.0"
+version = "0.7.3"
 
 [[Blosc_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Lz4_jll", "Pkg", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "e747dac84f39c62aff6956651ec359686490134e"
+git-tree-sha1 = "91d6baa911283650df649d0aea7c28639273ae7b"
 uuid = "0b7ba130-8d10-5ba8-a3d6-c5182647fed9"
-version = "1.21.0+0"
+version = "1.21.1+0"
 
 [[Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
+git-tree-sha1 = "19a35467a82e236ff51bc17a3a44b69ef35185a2"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
-version = "1.0.6+5"
+version = "1.0.8+0"
 
 [[Cairo_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "e2f47f6d8337369411569fd45ae5753ca10394c6"
+git-tree-sha1 = "4b859a208b2397a7a623a03449e4636bdb17bcf2"
 uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
-version = "1.16.0+6"
+version = "1.16.1+1"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "dcc25ff085cf548bc8befad5ce048391a7c07d40"
+git-tree-sha1 = "9950387274246d08af38f6eef8cb5480862a435f"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.11"
+version = "1.14.0"
+
+[[ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.2"
 
 [[ColorSchemes]]
-deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "StaticArrays"]
-git-tree-sha1 = "ed268efe58512df8c7e224d2e170afd76dd6a417"
+deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random"]
+git-tree-sha1 = "12fc73e5e0af68ad3137b886e3f7c1eacfca2640"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.13.0"
+version = "3.17.1"
 
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
@@ -77,19 +89,20 @@ version = "0.12.8"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
+git-tree-sha1 = "96b0bc6c52df76506efc8a441c6cf1adcb1babc4"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.31.0"
+version = "3.42.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "0.5.0+0"
 
 [[Conda]]
-deps = ["JSON", "VersionParsing"]
-git-tree-sha1 = "299304989a5e6473d985212c28928899c74e9421"
+deps = ["Downloads", "JSON", "VersionParsing"]
+git-tree-sha1 = "6e47d11ea2776bc5627421d59cdcc1296c058071"
 uuid = "8f4d0f93-b110-5947-807f-2305c1781a2d"
-version = "1.5.2"
+version = "1.7.0"
 
 [[Contour]]
 deps = ["StaticArrays"]
@@ -104,15 +117,15 @@ uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 version = "0.6.10"
 
 [[DataAPI]]
-git-tree-sha1 = "ee400abb2298bd13bfc3df1c412ed228061a2385"
+git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.7.0"
+version = "1.9.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
+git-tree-sha1 = "3daef5523dd2e769dad2365274f760ff5f282c7d"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.9"
+version = "0.18.11"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -133,36 +146,37 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2"]
-git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.5"
+version = "0.8.6"
 
 [[Documenter]]
-deps = ["Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "47f13b6305ab195edb73c86815962d84e31b0f48"
+deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "7d9a46421aef53cbd6b8ecc40c3dcbacbceaf40e"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.3"
+version = "0.27.15"
 
 [[Downloads]]
-deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+deps = ["ArgTools", "FileWatching", "LibCURL", "NetworkOptions"]
 uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.6.0"
 
 [[EarCut_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "92d8f9f208637e8d2d28c664051a00569c01493d"
+git-tree-sha1 = "3f3a2501fa7236e9b911e0f7a588c657e822bb6d"
 uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
-version = "2.1.5+1"
+version = "2.2.3+0"
 
 [[Expat_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "b3bfd02e98aedfa5cf885665493c5598c350cd2f"
+git-tree-sha1 = "ae13fcbc7ab8f16b0856729b050ef0c446aa3492"
 uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
-version = "2.2.10+0"
+version = "2.4.4+0"
 
 [[ExprTools]]
-git-tree-sha1 = "b7e3d17636b348f005f11040025ae8c6f645fe92"
+git-tree-sha1 = "56559bbef6ca5ea0c0818fa5c90320398a6fbf8d"
 uuid = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
-version = "0.1.6"
+version = "0.1.8"
 
 [[FFMPEG]]
 deps = ["FFMPEG_jll"]
@@ -171,22 +185,25 @@ uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
 version = "0.4.1"
 
 [[FFMPEG_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "LibVPX_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
-git-tree-sha1 = "3cc57ad0a213808473eafef4845a74766242e05f"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
+git-tree-sha1 = "d8a578692e3077ac998b50c0217dfd67f21d1e5f"
 uuid = "b22a6f82-2f65-5046-a5b2-351ab43fb4e5"
-version = "4.3.1+4"
+version = "4.4.0+0"
 
 [[FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
-git-tree-sha1 = "f985af3b9f4e278b1d24434cbb546d6092fca661"
+git-tree-sha1 = "505876577b5481e50d089c1c68899dfb6faebc62"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.4.3"
+version = "1.4.6"
 
 [[FFTW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "3676abafff7e4ff07bbd2c42b3d8201f31653dcc"
+git-tree-sha1 = "c6033cc3892d0ef5bb9cd29b7f2f0331ea5184ea"
 uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
-version = "3.3.9+8"
+version = "3.3.10+0"
+
+[[FileWatching]]
+uuid = "7b1f6079-737a-58dc-b8bc-7a2ca5c1b5ee"
 
 [[FixedPointNumbers]]
 deps = ["Statistics"]
@@ -196,9 +213,9 @@ version = "0.8.4"
 
 [[Fontconfig_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "35895cf184ceaab11fd778b4590144034a167a2f"
+git-tree-sha1 = "21efd19106a55620a188615da6d3d06cd7f6ee03"
 uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
-version = "2.13.1+14"
+version = "2.13.93+0"
 
 [[Formatting]]
 deps = ["Printf"]
@@ -208,9 +225,9 @@ version = "0.4.2"
 
 [[FreeType2_jll]]
 deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "cbd58c9deb1d304f5a245a0b7eb841a2560cfec6"
+git-tree-sha1 = "87eb71354d8ec1a96d4a7636bd57a7347dde3ef9"
 uuid = "d7e528f0-a631-5988-bf34-fe36492bcfd7"
-version = "2.10.1+5"
+version = "2.10.4+0"
 
 [[FriBidi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -218,40 +235,36 @@ git-tree-sha1 = "aa31987c2ba8704e23c6c8ba8a4f769d5d7e4f91"
 uuid = "559328eb-81f9-559d-9380-de523a88c83c"
 version = "1.0.10+0"
 
-[[Future]]
-deps = ["Random"]
-uuid = "9fa8497b-333b-5362-9e8d-4d0656e87820"
-
 [[GLFW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pkg", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll"]
-git-tree-sha1 = "dba1e8614e98949abfa60480b13653813d8f0157"
+git-tree-sha1 = "51d2dfe8e590fbd74e7a842cf6d13d8a2f45dc01"
 uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
-version = "3.3.5+0"
+version = "3.3.6+0"
 
 [[GR]]
-deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "b83e3125048a9c3158cbb7ca423790c7b1b57bea"
+deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "9f836fb62492f4b0f0d3b06f55983f2704ed0883"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.57.5"
+version = "0.64.0"
 
 [[GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "e14907859a1d3aee73a019e7b3c98e9e7b8b5b3e"
+git-tree-sha1 = "a6c850d77ad5118ad3be4bd188919ce97fffac47"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.57.3+0"
+version = "0.64.0+0"
 
 [[Geodesics]]
-git-tree-sha1 = "40b419c50a36adadfe85a9cca7ed12255779f1ce"
+git-tree-sha1 = "9fa57f6c5a42ef1f72539bc60c30dae18e5f32d4"
 repo-rev = "master"
 repo-url = "https://github.com/anowacki/Geodesics.jl"
 uuid = "6aaf26a4-c633-11e8-35ae-8904cb805353"
-version = "0.2.3"
+version = "0.2.4"
 
 [[GeometryBasics]]
 deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
-git-tree-sha1 = "15ff9a14b9e1218958d3530cc288cf31465d9ae2"
+git-tree-sha1 = "83ea630384a13fc4f002b77690bc0afeb4255ac9"
 uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
-version = "0.3.13"
+version = "0.4.2"
 
 [[Gettext_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
@@ -261,14 +274,20 @@ version = "0.21.0+0"
 
 [[Glib_jll]]
 deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "47ce50b742921377301e15005c96e979574e130b"
+git-tree-sha1 = "a32d672ac2c967f3deb8a81d828afc739c838a06"
 uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
-version = "2.68.1+0"
+version = "2.68.3+2"
 
 [[Glob]]
 git-tree-sha1 = "4df9f7e06108728ebf00a0a11edee4b29a482bb2"
 uuid = "c27321d9-0574-5035-807b-f59d2c89b15c"
 version = "1.3.0"
+
+[[Graphite2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "344bf40dcab1073aca04aa0df4fb092f920e4011"
+uuid = "3b182d85-2403-5c21-9c21-1e1f0cc25472"
+version = "1.3.14+0"
 
 [[Grisu]]
 git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
@@ -293,6 +312,12 @@ git-tree-sha1 = "c7ec02c4c6a039a98a15f955462cd7aea5df4508"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
 version = "0.8.19"
 
+[[HarfBuzz_jll]]
+deps = ["Artifacts", "Cairo_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "Graphite2_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg"]
+git-tree-sha1 = "129acf094d168394e80ee1dc4bc06ec835e510a3"
+uuid = "2e76f6c2-a576-52d4-95c1-20adfe4de566"
+version = "2.8.1+1"
+
 [[IOCapture]]
 deps = ["Logging", "Random"]
 git-tree-sha1 = "f7be53659ab06ddc986428d3a9dcc95f6fa6705a"
@@ -300,10 +325,15 @@ uuid = "b5f81e59-6552-4d32-b1f0-c071b021bf89"
 version = "0.2.2"
 
 [[IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
+git-tree-sha1 = "f550e6e32074c939295eb5ea6de31849ac2c9625"
 uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
+version = "0.5.1"
+
+[[InlineStrings]]
+deps = ["Parsers"]
+git-tree-sha1 = "61feba885fac3a407465726d0c330b3055df897f"
+uuid = "842dd82b-1e85-43dc-bf29-5d0ee9dffc48"
+version = "1.1.2"
 
 [[IntelOpenMP_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -321,10 +351,21 @@ git-tree-sha1 = "323a38ed1952d30586d0fe03412cde9399d3618b"
 uuid = "d8418881-c3e1-53bb-8760-2df7ec849ed5"
 version = "1.5.0"
 
+[[InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "91b5dcf362c5add98049e6c29ee756910b03051d"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.3"
+
+[[IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
 [[IterTools]]
-git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+git-tree-sha1 = "fa6287a4469f5e048d763df38279ee729fbd44e5"
 uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
-version = "1.3.0"
+version = "1.4.0"
 
 [[IteratorInterfaceExtensions]]
 git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
@@ -333,27 +374,33 @@ version = "1.0.0"
 
 [[JLLWrappers]]
 deps = ["Preferences"]
-git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+git-tree-sha1 = "abc9885a7ca2052a736a600f7fa66209f96506e1"
 uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
-version = "1.3.0"
+version = "1.4.1"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "3c837543ddb02250ef42f4738347454f95079d4e"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.3"
 
 [[JpegTurbo_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "d735490ac75c5cb9f1b00d8b5509c11984dc6943"
+git-tree-sha1 = "b53380851c6e6664204efb2e62cd24fa5c47e4ba"
 uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
-version = "2.1.0+0"
+version = "2.1.2+0"
 
 [[LAME_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "f6250b16881adf048549549fba48b1161acdac8c"
 uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
 version = "3.100.1+0"
+
+[[LERC_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "bf36f528eec6634efc60d7ec062008f171071434"
+uuid = "88015f11-f218-50d7-93a8-a6af411a945d"
+version = "3.0.0+1"
 
 [[LZO_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -362,15 +409,15 @@ uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
 version = "2.10.1+0"
 
 [[LaTeXStrings]]
-git-tree-sha1 = "c7f1c695e06c01b95a67f0cd1d34994f3e7db104"
+git-tree-sha1 = "f2355693d6778a178ade15952b7ac47a4ff97996"
 uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
-version = "1.2.1"
+version = "1.3.0"
 
 [[Latexify]]
 deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "Printf", "Requires"]
-git-tree-sha1 = "a4b12a1bd2ebade87891ab7e36fdbce582301a92"
+git-tree-sha1 = "4f00cc36fede3c04b8acf9b2e2763decfdcecfa6"
 uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
-version = "0.15.6"
+version = "0.15.13"
 
 [[LazyArtifacts]]
 deps = ["Artifacts", "Pkg"]
@@ -379,10 +426,12 @@ uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
 [[LibCURL]]
 deps = ["LibCURL_jll", "MozillaCACerts_jll"]
 uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
 
 [[LibCURL_jll]]
 deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
 uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.81.0+0"
 
 [[LibGit2]]
 deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
@@ -391,21 +440,16 @@ uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
 [[LibSSH2_jll]]
 deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
 uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
-
-[[LibVPX_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "12ee7e23fa4d18361e7c2cde8f8337d4c3101bc7"
-uuid = "dd192d2f-8180-539f-9fb4-cc70b1dcf69a"
-version = "1.10.0+0"
+version = "1.10.2+0"
 
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
 [[Libffi_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "761a393aeccd6aa92ec3515e428c26bf99575b3b"
+git-tree-sha1 = "0b4a5d71f3e5200a7dff793393e09dfc2d874290"
 uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
-version = "3.2.2+0"
+version = "3.2.2+1"
 
 [[Libgcrypt_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll", "Pkg"]
@@ -438,10 +482,10 @@ uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
 version = "2.35.0+0"
 
 [[Libtiff_jll]]
-deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "340e257aada13f95f98ee352d316c3bed37c8ab9"
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "c9551dd26e31ab17b86cbd00c2ede019c08758eb"
 uuid = "89763e89-9b03-5906-acba-b20f662cd828"
-version = "4.3.0+0"
+version = "4.3.0+1"
 
 [[Libuuid_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -456,14 +500,14 @@ uuid = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
 version = "0.8.1"
 
 [[LinearAlgebra]]
-deps = ["Libdl"]
+deps = ["Libdl", "libblastrampoline_jll"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
-deps = ["DocStringExtensions", "LinearAlgebra"]
-git-tree-sha1 = "7bd5f6565d80b6bf753738d2bc40a5dfea072070"
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "58f25e56b706f95125dcb796f39e1fb01d913a71"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.2.5"
+version = "0.3.10"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -476,15 +520,15 @@ version = "1.9.3+0"
 
 [[MKL_jll]]
 deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
-git-tree-sha1 = "c253236b0ed414624b083e6b72bfe891fbd2c7af"
+git-tree-sha1 = "e595b205efd49508358f7dc670a940c790204629"
 uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
-version = "2021.1.1+1"
+version = "2022.0.0+0"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.6"
+version = "0.5.9"
 
 [[Markdown]]
 deps = ["Base64"]
@@ -499,6 +543,7 @@ version = "1.0.3"
 [[MbedTLS_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+version = "2.28.0+0"
 
 [[Measures]]
 git-tree-sha1 = "e498ddeee6f9fdb4551ce855a46f54dbd900245f"
@@ -507,47 +552,59 @@ version = "0.3.1"
 
 [[Missings]]
 deps = ["DataAPI"]
-git-tree-sha1 = "4ea90bd5d3985ae1f9a908bd4500ae88921c5ce7"
+git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "1.0.0"
+version = "1.0.2"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Mocking]]
-deps = ["ExprTools"]
-git-tree-sha1 = "916b850daad0d46b8c71f65f719c49957e9513ed"
+deps = ["Compat", "ExprTools"]
+git-tree-sha1 = "29714d0a7a8083bba8427a4fbfb00a540c681ce7"
 uuid = "78c3b35d-d492-501b-9361-3d52fe80e533"
-version = "0.7.1"
+version = "0.7.3"
 
 [[MozillaCACerts_jll]]
 uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2022.2.1"
 
 [[NaNMath]]
-git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
+git-tree-sha1 = "737a5957f387b17e74d4ad2f440eb330b39a62c5"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
-version = "0.3.5"
+version = "1.0.0"
 
 [[NetworkOptions]]
 uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+version = "1.2.0"
 
 [[OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "2bf78c5fd7fa56d2bbf1efbadd45c1b8789e6f57"
+git-tree-sha1 = "043017e0bdeff61cfbb7afeb558ab29536bbb5ed"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.10.2"
+version = "1.10.8"
 
 [[Ogg_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "7937eda4681660b4d6aeeecc2f7e1c81c8ee4e2f"
+git-tree-sha1 = "887579a3eb005446d514ab7aeac5d1d027658b8f"
 uuid = "e7412a2a-1a6e-54c0-be00-318e2571c051"
-version = "1.3.5+0"
+version = "1.3.5+1"
+
+[[OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.17+2"
+
+[[OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.8.1+0"
 
 [[OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "15003dcb7d8db3c6c857fda14891a539a8f2705a"
+git-tree-sha1 = "ab05aa4cc89736e95915b01e7279e61b1bfe33b8"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.10+0"
+version = "1.1.14+0"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -574,9 +631,9 @@ version = "8.44.0+0"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
+git-tree-sha1 = "85b5da0fa43588c75bb1ff986493443f821c70b7"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.1.0"
+version = "2.2.3"
 
 [[Pixman_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -587,6 +644,7 @@ version = "0.40.1+0"
 [[Pkg]]
 deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
 uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+version = "1.8.0"
 
 [[PlotThemes]]
 deps = ["PlotUtils", "Requires", "Statistics"]
@@ -596,15 +654,15 @@ version = "2.0.1"
 
 [[PlotUtils]]
 deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
-git-tree-sha1 = "501c20a63a34ac1d015d5304da0e645f42d91c9f"
+git-tree-sha1 = "bb16469fd5224100e422f0b027d26c5a25de1200"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.0.11"
+version = "1.2.0"
 
 [[Plots]]
-deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
-git-tree-sha1 = "f32cd6fcd2909c2d1cdd47ce55e1394b04a66fe2"
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
+git-tree-sha1 = "90021b03a38f1ae9dbd7bf4dc5e3dcb7676d302c"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.18.2"
+version = "1.27.2"
 
 [[Polynomials]]
 deps = ["Intervals", "LinearAlgebra", "OffsetArrays", "RecipesBase"]
@@ -614,9 +672,9 @@ version = "1.2.1"
 
 [[Preferences]]
 deps = ["TOML"]
-git-tree-sha1 = "00cfd92944ca9c760982747e9a1d0d5d86ab1e5a"
+git-tree-sha1 = "d3538e7f8a790dc8903519090857ef8e1283eecd"
 uuid = "21216c6a-2e73-6563-6e65-726566657250"
-version = "1.2.2"
+version = "1.2.5"
 
 [[Printf]]
 deps = ["Unicode"]
@@ -624,9 +682,9 @@ uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [[PyCall]]
 deps = ["Conda", "Dates", "Libdl", "LinearAlgebra", "MacroTools", "Serialization", "VersionParsing"]
-git-tree-sha1 = "169bb8ea6b1b143c5cf57df6d34d022a7b60c6db"
+git-tree-sha1 = "1fc929f47d7c151c839c5fc1375929766fb8edcc"
 uuid = "438e738f-606a-5dbb-bf0a-cddfbfd45ab0"
-version = "1.92.3"
+version = "1.93.1"
 
 [[Qt5Base_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "xkbcommon_jll"]
@@ -639,33 +697,40 @@ deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
 
 [[Random]]
-deps = ["Serialization"]
+deps = ["SHA", "Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RecipesBase]]
-git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
+git-tree-sha1 = "6bf3f380ff52ce0832ddd3a2a7b9538ed1bcca7d"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.1.1"
+version = "1.2.1"
 
 [[RecipesPipeline]]
 deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
-git-tree-sha1 = "2a7a2469ed5d94a98dea0e85c46fa653d76be0cd"
+git-tree-sha1 = "dc1e451e15d90347a7decc4221842a022b011714"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.3.4"
+version = "0.5.2"
 
 [[Reexport]]
-git-tree-sha1 = "5f6c21241f0f655da3952fd60aa18477cf96c220"
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "1.1.0"
+version = "1.2.2"
+
+[[RelocatableFolders]]
+deps = ["SHA", "Scratch"]
+git-tree-sha1 = "cdbd3b1338c72ce29d9584fdbe9e9b70eeb5adca"
+uuid = "05181044-ff0b-4ac5-8273-598c1e38db00"
+version = "0.1.3"
 
 [[Requires]]
 deps = ["UUIDs"]
-git-tree-sha1 = "4036a3bd08ac7e968e27c203d45f5fff15020621"
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
 uuid = "ae029012-a4dd-5104-9daa-d747884805df"
-version = "1.1.3"
+version = "1.3.0"
 
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
 
 [[Scratch]]
 deps = ["Dates"]
@@ -674,10 +739,10 @@ uuid = "6c6a2e73-6563-6170-7368-637461726353"
 version = "1.1.0"
 
 [[Seis]]
-deps = ["DSP", "Dates", "Geodesics", "Glob", "LinearAlgebra", "RecipesBase", "SeisIO", "Statistics"]
+deps = ["DSP", "Dates", "Geodesics", "Glob", "LinearAlgebra", "RecipesBase", "SeisIO", "StaticArrays", "Statistics"]
 path = ".."
 uuid = "dd80f4d8-c2f6-58bd-9bd3-4635f134261d"
-version = "0.3.9"
+version = "0.3.10"
 
 [[SeisIO]]
 deps = ["Blosc", "DSP", "Dates", "DelimitedFiles", "FFTW", "Glob", "HDF5", "HTTP", "LightXML", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "Random", "Sockets", "Statistics", "Test"]
@@ -720,41 +785,43 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["ChainRulesCore", "LogExpFunctions", "OpenSpecFun_jll"]
-git-tree-sha1 = "a50550fa3164a8c46747e62063b4d774ac1bcf49"
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "cbf21db885f478e4bd73b286af6e67d1beeebe4c"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.5.1"
+version = "1.8.4"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "a43a7b58a6e7dc933b2fa2e0ca653ccf8bb8fd0e"
+git-tree-sha1 = "6976fab022fea2ffea3d945159317556e5dad87c"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.6"
+version = "1.4.2"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
 uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StatsAPI]]
-git-tree-sha1 = "1958272568dc176a1d881acb797beb909c785510"
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "c3d8ba7f3fa0625b062b82853a7d5229cb728b6b"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.0.0"
+version = "1.2.1"
 
 [[StatsBase]]
-deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "2f6792d523d7448bbe2fec99eca9218f06cc746d"
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "8977b17906b0a1cc74ab2e3a05faa16cf08a8291"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.8"
+version = "0.33.16"
 
 [[StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
-git-tree-sha1 = "000e168f5cc9aded17b6999a560b7c11dda69095"
+git-tree-sha1 = "57617b34fa34f91d536eb265df67c2d4519b8b98"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.0"
+version = "0.6.5"
 
 [[TOML]]
 deps = ["Dates"]
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.0"
 
 [[TableTraits]]
 deps = ["IteratorInterfaceExtensions"]
@@ -763,14 +830,15 @@ uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
 version = "1.0.1"
 
 [[Tables]]
-deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
-git-tree-sha1 = "8ed4a3ea724dac32670b062be3ef1c1de6773ae8"
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "OrderedCollections", "TableTraits", "Test"]
+git-tree-sha1 = "5ce79ce186cc678bbb5c5681ca3379d1ddae11a1"
 uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
-version = "1.4.4"
+version = "1.7.0"
 
 [[Tar]]
 deps = ["ArgTools", "SHA"]
 uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+version = "1.10.0"
 
 [[TauPy]]
 deps = ["PyCall"]
@@ -785,10 +853,10 @@ deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TimeZones]]
-deps = ["Dates", "Future", "LazyArtifacts", "Mocking", "Pkg", "Printf", "RecipesBase", "Serialization", "Unicode"]
-git-tree-sha1 = "81753f400872e5074768c9a77d4c44e70d409ef0"
+deps = ["Dates", "Downloads", "InlineStrings", "LazyArtifacts", "Mocking", "Printf", "RecipesBase", "Serialization", "Unicode"]
+git-tree-sha1 = "2d4b6de8676b34525ac518de36006dc2e89c7e2e"
 uuid = "f269a46b-ccf7-5d73-abea-4c690281aa53"
-version = "1.5.6"
+version = "1.7.2"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -797,10 +865,21 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
+[[UnicodeFun]]
+deps = ["REPL"]
+git-tree-sha1 = "53915e50200959667e78a92a418594b428dffddf"
+uuid = "1cfade01-22cf-5700-b092-accc4b62d6e1"
+version = "0.4.1"
+
+[[Unzip]]
+git-tree-sha1 = "34db80951901073501137bdbc3d5a8e7bbd06670"
+uuid = "41fe7b60-77ed-43a1-b4f0-825fd5a5650d"
+version = "0.1.2"
+
 [[VersionParsing]]
-git-tree-sha1 = "80229be1f670524750d905f8fc8148e5a8c4537f"
+git-tree-sha1 = "58d6e80b4ee071f5efd07fda82cb9fbe17200868"
 uuid = "81def892-9a0e-5fdd-b105-ffc91e053289"
-version = "1.2.0"
+version = "1.3.0"
 
 [[Wayland_jll]]
 deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
@@ -809,10 +888,10 @@ uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
 version = "1.19.0+0"
 
 [[Wayland_protocols_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll"]
-git-tree-sha1 = "2839f1c1296940218e35df0bbb220f2a79686670"
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4528479aa01ee1b3b4cd0e6faef0e04cf16466da"
 uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
-version = "1.18.0+4"
+version = "1.25.0+0"
 
 [[XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
@@ -955,24 +1034,30 @@ version = "1.4.0+3"
 [[Zlib_jll]]
 deps = ["Libdl"]
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+version = "1.2.12+1"
 
 [[Zstd_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "cc4bf3fdde8b7e3e9fa0351bdeedba1cf3b7f6e6"
+git-tree-sha1 = "e45044cd873ded54b6a5bac0eb5c971392cf1927"
 uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
-version = "1.5.0+0"
+version = "1.5.2+0"
 
 [[libass_jll]]
-deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "acc685bcf777b2202a904cdcb49ad34c2fa1880c"
+deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "HarfBuzz_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "5982a94fcba20f02f42ace44b9894ee2b140fe47"
 uuid = "0ac62f75-1d6f-5e53-bd7c-93b484bb37c0"
-version = "0.14.0+4"
+version = "0.15.1+0"
+
+[[libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.0.1+0"
 
 [[libfdk_aac_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "7a5780a0d9c6864184b3a2eeeb833a0c871f00ab"
+git-tree-sha1 = "daacc84a041563f965be61859a36e17c4e4fcd55"
 uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
-version = "0.1.6+4"
+version = "2.0.2+0"
 
 [[libpng_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
@@ -982,29 +1067,31 @@ version = "1.6.38+0"
 
 [[libvorbis_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]
-git-tree-sha1 = "c45f4e40e7aafe9d086379e5578947ec8b95a8fb"
+git-tree-sha1 = "b910cb81ef3fe6e78bf6acee440bda86fd6ae00c"
 uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
-version = "1.3.7+0"
+version = "1.3.7+1"
 
 [[nghttp2_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.41.0+1"
 
 [[p7zip_jll]]
 deps = ["Artifacts", "Libdl"]
 uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"
+version = "16.2.1+1"
 
 [[x264_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "d713c1ce4deac133e3334ee12f4adff07f81778f"
+git-tree-sha1 = "4fea590b89e6ec504593146bf8b988b2c00922b2"
 uuid = "1270edf5-f2f9-52d2-97e9-ab00b5d0237a"
-version = "2020.7.14+2"
+version = "2021.5.5+0"
 
 [[x265_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "487da2f8f2f0c8ee0e83f39d13037d6bbf0a45ab"
+git-tree-sha1 = "ee567a171cce03570d77ad3a43e90218e38937a9"
 uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
-version = "3.0.0+3"
+version = "3.5.0+0"
 
 [[xkbcommon_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll", "Wayland_protocols_jll", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]

--- a/docs/src/function-index.md
+++ b/docs/src/function-index.md
@@ -103,6 +103,8 @@ rotate_to_gcp
 rotate_to_lqt!
 rotate_to_lqt
 rotate_to_azimuth_incidence!
+rotate_to_azimuth_incidence
+sort_traces_right_handed
 ```
 
 ### IO

--- a/docs/src/function-index.md
+++ b/docs/src/function-index.md
@@ -96,8 +96,13 @@ lowpass
 ```@docs
 rotate_through!
 rotate_through
+rotate_to_enz!
+rotate_to_enz
 rotate_to_gcp!
 rotate_to_gcp
+rotate_to_lqt!
+rotate_to_lqt
+rotate_to_azimuth_incidence!
 ```
 
 ### IO

--- a/docs/src/function-index.md
+++ b/docs/src/function-index.md
@@ -15,6 +15,7 @@ CartStation
 
 ### Accessor functions
 ```@docs
+are_orthogonal
 channel_code
 dates
 enddate

--- a/docs/src/internal-index.md
+++ b/docs/src/internal-index.md
@@ -22,3 +22,9 @@ Seis.Geographic
 Seis.Cartesian
 ```
 
+### Private functions
+
+#### 'Getters'
+```@docs
+Seis._angle_tol
+```

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -287,12 +287,22 @@ copying version, without.
 - Change the trace sampling interval with [`resample`](@ref) or
   [`resample!`](@ref)
 
-In addition, pairs of traces can be rotated:
+In addition, sets of traces can be rotated:
 - [`rotate_through`](@ref) and [`rotate_through!`](@ref) rotate
-  a pair of horizontal traces by a certain angle.
+  a pair of traces by a certain angle.
 - [`rotate_to_gcp`](@ref) and [`rotate_to_gcp!`](@ref) rotate pairs
   to radial (pointing away from the source at the station)
   and transverse (90° clockwise from this) components.
+- [`rotate_to_lqt`](@ref) and [`rotate_to_lqt!`](@ref) rotate triplets
+  of orthogonal compontents to longitudinal (L), transverse (T) and
+  Q (orthogonal to the others) orientations.
+- [`rotate_to_azimuth_incidence`](@ref) and
+  [`rotate_to_azimuth_incidence!`](@ref) rotate triplets of orthogonal
+  traces to arbitrary orientations.
+
+All of the above will use trace header information (coordinate of the
+event and station, and channel orientations) to automatically compute
+the directions if possible.
 
 
 ## Accessing raw trace data

--- a/src/Seis.jl
+++ b/src/Seis.jl
@@ -113,6 +113,7 @@ export
     rotate_through!,
     rotate_through,
     rotate_to_azimuth_incidence!,
+    rotate_to_azimuth_incidence,
     rotate_to_enz!,
     rotate_to_enz,
     rotate_to_gcp!,

--- a/src/Seis.jl
+++ b/src/Seis.jl
@@ -112,8 +112,14 @@ export
     # Rotation
     rotate_through!,
     rotate_through,
+    rotate_to_azimuth_incidence!,
+    rotate_to_enz!,
+    rotate_to_enz,
     rotate_to_gcp!,
-    rotate_to_gcp
+    rotate_to_gcp,
+    rotate_to_lqt!,
+    rotate_to_lqt,
+    sort_traces_right_handed
 
 using Dates
 using LinearAlgebra

--- a/src/Seis.jl
+++ b/src/Seis.jl
@@ -37,6 +37,7 @@ export
     Station,
     Trace,
     # 'Getters'
+    are_orthogonal,
     dates,
     enddate,
     endtime,
@@ -116,13 +117,17 @@ export
 
 using Dates
 using LinearAlgebra
+using LinearAlgebra: ×, ⋅, norm
 using Statistics: mean, covm, varm
 
 import Glob
 import DSP
 import DSP.resample
+import StaticArrays
 
 import Geodesics
+
+include("compat.jl")
 
 # All basic types
 include("types.jl")

--- a/src/compat.jl
+++ b/src/compat.jl
@@ -1,0 +1,5 @@
+# Compatibility with older Julia versions
+
+@static if VERSION < v"1.3"
+    sincosd(x) = (sind(x), cosd(x))
+end

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -19,7 +19,7 @@ The optional keyword argument `tol` specifies the angle in ° by which
 the traces must be orthogonal; see [`are_orthogonal`](@ref).
 
 See also: [`rotate_through`](@ref), [`rotate_to_gcp!`](@ref),
-[`rotate_to_azimuth_incidence!`]
+[`rotate_to_azimuth_incidence!`](@ref)
 """
 function rotate_through!(t1::AbstractTrace, t2::AbstractTrace, phi; tol=_angle_tol(t1, t2))
     T = promote_type(eltype(t1), eltype(t2))
@@ -91,6 +91,9 @@ seems rotatable and matches for the traces; then the correct component name is u
 Traces must be orthogonal and horizontal.  The optional keyword argument
 `tol` specifies the angle in ° by which
 the traces must be orthogonal; see [`are_orthogonal`](@ref).
+
+See also: [`rotate_to_lqt!`](@ref), [`rotate_to_azimuth_incidence!`](@ref),
+[`rotate_to_enz!`](@ref)
 """
 function rotate_to_gcp!(t1, t2; reverse::Bool=false, tol=_angle_tol(t1, t2))
     all(!ismissing, (t1.sta.azi, t1.sta.inc, t2.sta.azi, t2.sta.inc)) ||
@@ -170,8 +173,8 @@ altered, and the returned traces point to the same data as the input traces, but
 possibly in a different order.  Use [`rotate_to_azimuth_incidence`](@ref) to return
 copies of the traces and leave the original traces unmodified.
 
-See also: [`rotate_to_azimuth_incidence`](@ref), [`rotate_to_gcp!`](@ref),
-[`rotate_to_lqt!`](@ref), [`rotate_through`](@ref)
+See also: [`rotate_to_azimuth_incidence!`](@ref), [`rotate_to_gcp!`](@ref),
+[`rotate_to_lqt!`](@ref), [`rotate_through!`](@ref)
 """
 function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::AbstractTrace,
         azimuth=backazimuth(t1)+180, incidence=incidence(t1);
@@ -344,6 +347,9 @@ julia> t.sta.cha
 julia> l == e, q == n, t == z # Original traces are modified and returned in a possibly different order
 (true, true, true)
 ```
+
+See also: [`rotate_through!`](@ref), [`rotate_to_azimuth_incidence!`](@ref),
+[`rotate_to_enz`](@ref)
 """
 function rotate_to_lqt!(t1, t2, t3, azimuth, incidence; tol=_angle_tol(t1, t2, t3))
     l, q, t = rotate_to_azimuth_incidence!(t1, t2, t3, azimuth, incidence; tol=tol)
@@ -378,6 +384,9 @@ east (`e`), north (`n`) and vertically (`z`).
 `e`, `n` and `z` are bindings to the same data as `t1`, `t2` and `t3`,
 but they may not be returned in the same order as passed in if the original
 set of traces are not given as a right-handed set.
+
+See also: [`rotate_through!`](@ref), [`rotate_to_gcp!`](@ref),
+[`rotate_to_lqt!`](@ref)
 """
 function rotate_to_enz!(t1, t2, t3; tol=_angle_tol(t1, t2, t3))
     n, z, e = rotate_to_azimuth_incidence!(t1, t2, t3, 0, 90; tol=tol)

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -389,10 +389,13 @@ end
 Return `true` if `s` is a string conforming to SEED channel naming conventions which
 describes a channel for which it makes sense to rotate a matching pair of these channels.
 
+Returns `false` if the above does not hold or `s` is `missing`.
+
 #### References
 - https://ds.iris.edu/ds/nodes/dmc/data/formats/seed-channel-naming/
 """
 _is_rotatable_seed_channel_name(s) = occursin(r"^[FGDCESHBMLVURPTQAO][HLGMNAFJPSXYZ][ZNEABCTR123UVW]$", s)
+_is_rotatable_seed_channel_name(::Missing) = false
 
 """
     _construct_rotation_matrix(uˣ, uʸ, uᶻ, uˣ′, uʸ′, uᶻ′) -> R

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -16,7 +16,7 @@ Trace channel names are updated to contain the azimuth if both
 channels are horizontals.
 
 The optional keyword argument `tol` specifies the angle in ° by which
-the traces must be orthogonal; see [`traces_are_orthogonal`](@ref).
+the traces must be orthogonal; see [`are_orthogonal`](@ref).
 
 See also: [`rotate_through`](@ref), [`rotate_to_gcp!`](@ref),
 [`rotate_to_azimuth_incidence!`]
@@ -90,7 +90,7 @@ seems rotatable and matches for the traces; then the correct component name is u
 
 Traces must be orthogonal and horizontal.  The optional keyword argument
 `tol` specifies the angle in ° by which
-the traces must be orthogonal; see [`traces_are_orthogonal`](@ref).
+the traces must be orthogonal; see [`are_orthogonal`](@ref).
 """
 function rotate_to_gcp!(t1, t2; reverse::Bool=false, tol=_angle_tol(t1, t2))
     all(!ismissing, (t1.sta.azi, t1.sta.inc, t2.sta.azi, t2.sta.inc)) ||

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -257,7 +257,7 @@ end
 Copying version of [`rotate_to_azimuth_incidence`](@ref).
 """
 function rotate_to_azimuth_incidence(t1, t2, t3, azimuth=backazimuth(t1)+180,
-    incidence=incidence(t1); tol=_angle_tol(t1, t2, t3))
+        incidence=incidence(t1); tol=_angle_tol(t1, t2, t3))
     rotate_to_azimuth_incidence!(deepcopy.((t1, t2, t3))..., azimuth, incidence; tol=tol)
 end
 

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -139,7 +139,9 @@ function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::
     0 <= incidence <= 180 ||
         throw(ArgumentError("incidence must be in the range 0 to 180"))
     # Check traces
-    if !are_orthogonal(t1, t2, t3)
+    if any(x -> x.sta.azi === missing || x.sta.inc === missing, (t1, t2, t3))
+        throw(ArgumentError("traces must contain station orientation information"))
+    elseif !are_orthogonal(t1, t2, t3)
         throw(ArgumentError("traces must be orthogonal"))
     elseif !(axes(trace(t1)) == axes(trace(t2)) == axes(trace(t3)))
         throw(ArgumentError("traces must all be the same length"))

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -230,11 +230,11 @@ function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::
     z.sta.azi, z.sta.inc = azᶻ, incᶻ
 
     for (i, t) in enumerate((x, y, z))
-        code = if isapprox(t.sta.inc, 0, atol=tol)
+        code = if is_vertical(t.sta; tol=tol)
             "Z"
-        elseif isapprox(t.sta.inc, 90, atol=tol) && isapprox(t.sta.azi, 0, atol=tol)
+        elseif is_north(t; tol=tol)
             "N"
-        elseif isapprox(t.sta.inc, 90, atol=tol) && isapprox(t.sta.azi, 90, atol=tol)
+        elseif is_east(t; tol=tol)
             "E"
         else
             string(i)

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -179,7 +179,7 @@ function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::
     tx = trace(x)
     ty = trace(y)
     tz = trace(z)
-    @inbounds for i in eachindex(tx)    
+    @inbounds for i in eachindex(tx)
         tx[i], ty[i], tz[i] = rotation_matrix*StaticArrays.@SVector[tx[i], ty[i], tz[i]]
     end
 
@@ -248,7 +248,7 @@ between event and receiver.
     `              |
       `            |
         `
-          ∇ (station) 
+          ∇ (station)
          ⊙ `
       -  Q   `
     ↙          ↘
@@ -262,7 +262,7 @@ between event and receiver.
  Up               |
  ↑                 |
  |                  |      __ → L
- |      (station)  ∇ ⊙__--- 
+ |      (station)  ∇ ⊙__---
              .__--   T
         .__--
     __--

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -95,6 +95,7 @@ the traces must be orthogonal; see [`traces_are_orthogonal`](@ref).
 function rotate_to_gcp!(t1, t2; reverse::Bool=false, tol=_angle_tol(t1, t2))
     all(!ismissing, (t1.sta.azi, t1.sta.inc, t2.sta.azi, t2.sta.inc)) ||
         throw(ArgumentError("Traces must have sta.inc and sta.azi defined"))
+    all(is_horizontal, (t1, t2)) || throw(ArgumentError("traces must be horizontal"))
     t2_is_clockwise_of_t1 = angle_difference(t1.sta.azi, t2.sta.azi) > 0
     t2_is_clockwise_of_t1 && ((t1, t2) = (t2, t1))
     # Keep band and instrument codes only if the channel name is a valid SEED identifier and seems rotatable,

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -304,11 +304,12 @@ function rotate_to_lqt!(t1, t2, t3, azimuth=backazimuth(t1)+180, incidence=incid
 end
 
 """
-    rotate_to_lqt(t1, t2, t3[; tol]) -> l, q, t
+    rotate_to_lqt(t1, t2, t3[, azimuth[, incidence]; tol) -> l, q, t
 
 Copying version of [`rotate_to_lqt!`](@ref).
 """
-rotate_to_lqt(t1, t2, t3; kwargs...) = rotate_to_lqt!(deepcopy.((t1, t2, t3))...; kwargs...)
+rotate_to_lqt(t1, t2, t3, args...; kwargs...) =
+    rotate_to_lqt!(deepcopy.((t1, t2, t3))..., args...; kwargs...)
 
 """
     rotate_to_enz!(t1, t2, t3[; tol]) -> e, n, z

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -322,7 +322,7 @@ but they may not be returned in the same order as passed in if the original
 set of traces are not given as a right-handed set.
 """
 function rotate_to_enz!(t1, t2, t3; tol=_angle_tol(t1, t2, t3))
-    e, n, z = rotate_to_azimuth_incidence!(t1, t2, t3, 0, 90; tol=tol)
+    n, z, e = rotate_to_azimuth_incidence!(t1, t2, t3, 0, 90; tol=tol)
     for (t, cha) in zip((e, n, z), ("E", "N", "Z"))
         if _is_rotatable_seed_channel_name(t.sta.cha)
             t.sta.cha = t.sta.cha[1:2] * cha

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -262,7 +262,9 @@ function rotate_to_azimuth_incidence(t1, t2, t3, azimuth=backazimuth(t1)+180,
 end
 
 """
-    rotate_to_lqt!(t1, t2, t3[, azimuth, [incidence]]; [tol]) -> L, Q, T
+    rotate_to_lqt!(t1, t2, t3; [tol]) -> L, Q, T
+    rotate_to_lqt!(t1, t2, t3, incidence; [tol]) -> L, Q, T
+    rotate_to_lqt!(t1, t2, t3, azimuth, incidence; [tol]) -> L, Q, T
 
 Rotate the three traces `t1`, `t2` and `t3` in place, and return them in the
 order `L`, `Q` and `T`, forming a right-handed set.
@@ -278,9 +280,10 @@ The `Q` direction is perpendicular to both, lying in the saggital plane, with
 some component in the vertical direction.
 
 If `azimuth` and `inclination` are not passed in explicitly, then they are
-determined using the event-station geometry.  This is only possible for
+determined using the event-station geometry.  This is only possible for both for
 `Trace`s in Cartesian geometry, since `inclination` is not well-determined in
-a geographic system.  For the Cartesian case, we assume straight-line paths
+a geographic system.  Geographic-system traces (the default) must pass at least
+the `inclination`.  For the Cartesian case, we assume straight-line paths
 between event and receiver.
 
 `tol` specifies the angle in ° by which the traces must be orthogonal; see
@@ -342,8 +345,7 @@ julia> l == e, q == n, t == z # Original traces are modified and returned in a p
 (true, true, true)
 ```
 """
-function rotate_to_lqt!(t1, t2, t3, azimuth=backazimuth(t1)+180, incidence=incidence(t1);
-        tol=_angle_tol(t1, t2, t3))
+function rotate_to_lqt!(t1, t2, t3, azimuth, incidence; tol=_angle_tol(t1, t2, t3))
     l, q, t = rotate_to_azimuth_incidence!(t1, t2, t3, azimuth, incidence; tol=tol)
     if _is_rotatable_seed_channel_name(l.sta.cha)
         cha = l.sta.cha
@@ -353,6 +355,11 @@ function rotate_to_lqt!(t1, t2, t3, azimuth=backazimuth(t1)+180, incidence=incid
     end
     l, q, t
 end
+
+rotate_to_lqt!(t1, t2, t3, incidence; kwargs...) =
+    rotate_to_lqt!(t1, t2, t3, backazimuth(t1)+180, incidence; kwargs...)
+rotate_to_lqt!(t1, t2, t3; kwargs...) =
+    rotate_to_lqt!(t1, t2, t3, backazimuth(t1)+180, incidence(t1); kwargs...)
 
 """
     rotate_to_lqt(t1, t2, t3[, azimuth[, incidence]; tol) -> l, q, t

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -252,6 +252,16 @@ function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::
 end
 
 """
+    rotate_to_azimuth_incidence(t1, t2, t3, azimuth, incidence[; tol]) -> x, y, z
+
+Copying version of [`rotate_to_azimuth_incidence`](@ref).
+"""
+function rotate_to_azimuth_incidence(t1, t2, t3, azimuth=backazimuth(t1)+180,
+    incidence=incidence(t1); tol=_angle_tol(t1, t2, t3))
+    rotate_to_azimuth_incidence!(deepcopy.((t1, t2, t3))..., azimuth, incidence; tol=tol)
+end
+
+"""
     rotate_to_lqt!(t1, t2, t3[, azimuth, [incidence]]; [tol]) -> L, Q, T
 
 Rotate the three traces `t1`, `t2` and `t3` in place, and return them in the

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -420,3 +420,20 @@ function _construct_rotation_matrix(uˣ, uʸ, uᶻ, uˣ′, uʸ′, uᶻ′)
                                uˣ′[3] uʸ′[3] uᶻ′[3]]
     transpose(R²)*R¹
 end
+
+"""
+    _rotate_by_vector(v, k, θ) -> v′
+
+Rotate the vector `v` about the vector `k` by `θ` radians,
+following the right-hand rule.  `k` need not be a unit vector.
+
+This implements Rodrigues's formula.
+
+# References
+- https://en.wikipedia.org/wiki/Rodrigues%27_rotation_formula
+"""
+function _rotate_by_vector(v, k, θ)
+    k̂ = normalize(k)
+    cosθ = cos(θ)
+    u′ = v*cosθ + (k̂×v)*sin(θ) + k̂*(k̂⋅v)*(1 - cosθ)
+end

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -1,43 +1,81 @@
 # Trace rotations
 
 """
-    rotate_through!(t1::Trace, t2::Trace, phi)
+    rotate_through!(t1::Trace, t2::Trace, phi[; tol]) -> t1, t2
 
-For two traces `t1` an `t2` which are horizontal and orthgonal, rotate
-them *clockwise* by `phi`° about the vertical axis.
+For two traces `t1` an `t2` which are orthgonal, rotate
+them by `phi`° from `t1` towards `t2`.  Note therefore that the
+**order of the arguments matters** and opposite rotations can
+be achieved by swapping `t1` and `t2`.  Neither of the traces need
+to be horizontal.
 
 This is a reference frame transformation (passive rotation) and hence particle motion
-will appear to rotate anti-clockwise.
+will appear to rotate from `t2` to `t1`.
+
+Trace channel names are updated to contain the azimuth if both
+channels are horizontals.
+
+The optional keyword argument `tol` specifies the angle in ° by which
+the traces must be orthogonal; see [`traces_are_orthogonal`](@ref).
+
+See also: [`rotate_through`](@ref), [`rotate_to_gcp!`](@ref),
+[`rotate_to_azimuth_incidence!`]
 """
-function rotate_through!(t1::AbstractTrace, t2::AbstractTrace, phi)
-    T = promote_type(eltype(trace(t1)), eltype(trace(t2)))
-    if !traces_are_orthogonal(t1, t2)
+function rotate_through!(t1::AbstractTrace, t2::AbstractTrace, phi; tol=_angle_tol(t1, t2))
+    T = promote_type(eltype(t1), eltype(t2))
+    if !are_orthogonal(t1, t2)
         throw(ArgumentError("traces must be orthogonal"))
-    elseif t1.sta.inc != t2.sta.inc != 90
-        throw(ArgumentError("traces must be horizontal"))
     elseif nsamples(t1) != nsamples(t2)
         throw(ArgumentError("traces must be same length"))
     elseif t1.delta != t2.delta
         throw(ArgumentError("traces must have same delta"))
     end
+
+    # The rotation assumes t2 is clockwise of t1.  If t1 is clockwise
+    # of t2, then we need to transpose the rotation matrix, which
+    # can be achieved by flipping the sign of `phi`.
+    t2_is_clockwise_of_t1 = angle_difference(t1.sta.azi, t2.sta.azi) > 0
+
     sinp, cosp = sincos(deg2rad(T(phi)))
     @inbounds for i = 1:nsamples(t1)
-        t1.t[i], t2.t[i] = cosp*t1.t[i] - sinp*t2.t[i], sinp*t1.t[i] + cosp*t2.t[i]
+        t1.t[i], t2.t[i] = cosp*t1.t[i] + sinp*t2.t[i], -sinp*t1.t[i] + cosp*t2.t[i]
     end
-    for t in (t1, t2)
-        t.sta.azi = mod(t.sta.azi + phi, 360)
-        t.sta.cha = string(round(t.sta.azi, digits=2, base=10))
+
+    # Old component orientations
+    u¹ = _direction_vector(t1)
+    u² = _direction_vector(t2)
+    # Get rotation vector (unnormalised, but that's okay)
+    k = u¹×u²
+    # New component orientations
+    ϕ = deg2rad(phi)
+    u¹′ = _rotate_by_vector(u¹, k, ϕ)
+    u²′ = _rotate_by_vector(u², k, ϕ)
+    az1, inc1 = _direction_to_azimuth_incidence(u¹′)
+    az2, inc2 = _direction_to_azimuth_incidence(u²′)
+
+    # Update trace orientations
+    for (t, az, inc) in zip((t1, t2), (az1, az2), (inc1, inc2))
+        t.sta.azi = az
+        t.sta.inc = inc
+        # Only update channel names to the azimuth if they are both horizontal
+        # FIXME: Update this to work the same as the other `rotate_*`
+        #        functions for the next minor version bump and update
+        #        NEWS.md.
+        if all(is_horizontal, (t1, t2))
+            t.sta.cha = string(round(t.sta.azi, digits=2, base=10))
+        end
     end
+
     t1, t2
 end
-rotate_through(t1::AbstractTrace, t2::AbstractTrace, phi) =
-    rotate_through!(deepcopy(t1), deepcopy(t2), phi)
+rotate_through(t1::AbstractTrace, t2::AbstractTrace, phi; tol=_angle_tol(t1, t2)) =
+    rotate_through!(deepcopy(t1), deepcopy(t2), phi; tol=tol)
 @doc (@doc rotate_through!) rotate_through
 
 """
-    rotate_to_gcp!(t1, t2; reverse=false) -> t1, t2
+    rotate_to_gcp!(t1, t2; reverse=false, tol) -> t1, t2
 
-Rotate the pair of traces `t1` and `t2` in place so that t1
+Rotate the pair of traces `t1` and `t2` in place so that `t1`
 points along the radial direction (the backazimuth plus 180°),
 and `t2` is 90° clockwise from that.
 
@@ -50,13 +88,15 @@ polarity, unless the component code is a valid SEED identifier which
 seems rotatable and matches for the traces; then the correct component name is used.
 (E.g., `"BHE"` and `"BHN"` become `"BHR"` and `"BHT"`.)
 
-Traces must be orthogonal and horizontal.
+Traces must be orthogonal and horizontal.  The optional keyword argument
+`tol` specifies the angle in ° by which
+the traces must be orthogonal; see [`traces_are_orthogonal`](@ref).
 """
-function rotate_to_gcp!(t1, t2; reverse::Bool=false)
+function rotate_to_gcp!(t1, t2; reverse::Bool=false, tol=_angle_tol(t1, t2))
     all(!ismissing, (t1.sta.azi, t1.sta.inc, t2.sta.azi, t2.sta.inc)) ||
         throw(ArgumentError("Traces must have sta.inc and sta.azi defined"))
     t2_is_clockwise_of_t1 = angle_difference(t1.sta.azi, t2.sta.azi) > 0
-    t2_is_clockwise_of_t1 || ((t1, t2) = (t2, t1))
+    t2_is_clockwise_of_t1 && ((t1, t2) = (t2, t1))
     # Keep band and instrument codes only if the channel name is a valid SEED identifier and seems rotatable,
     # and we aren't reversing the transverse
     code = first(t1.sta.cha, 2)
@@ -66,7 +106,7 @@ function rotate_to_gcp!(t1, t2; reverse::Bool=false)
     β ≈ backazimuth(t2) ||
         throw(ArgumentError("Backazimuth is not the same for both traces"))
     ϕ = mod(β + 180 - t1.sta.azi, 360)
-    rotate_through!(t2, t1, ϕ)
+    rotate_through!(t2, t1, ϕ; tol=tol)
     @assert t1.sta.azi ≈ mod(β + 180, 360)
     reverse && flip!(t2)
     # Channel code
@@ -83,7 +123,7 @@ function rotate_to_gcp!(t1, t2; reverse::Bool=false)
 end
 
 """
-    rotate_to_gcp!(t::AbstractArray{T); kwargs...)
+    rotate_to_gcp!(t::AbstractArray{T}; kwargs...) -> t
 
 Rotate pairs of traces in the array `t` so they are in the order
 `[R1, T1, R2, T2, ...]`.
@@ -105,8 +145,8 @@ function rotate_to_gcp!(t::AbstractArray{T}; kwargs...) where T<:AbstractTrace
 end
 
 """
-    rotate_to_gcp(t1, t2; reverse=false) -> R, T
-    rotate_to_gcp(t::AbstractArray{<:AbstractTrace}; reverse=false) -> t′
+    rotate_to_gcp(t1, t2; reverse=false[, tol]) -> R, T
+    rotate_to_gcp(t::AbstractArray{<:AbstractTrace}; reverse=false[, tol]) -> t′
 
 Copying version of `rotate_to_gcp!` which returns the radial `R` and
 transverse `T` traces in the first form, or pairs of radial and

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -290,7 +290,7 @@ the `inclination`.  For the Cartesian case, we assume straight-line paths
 between event and receiver.
 
 `tol` specifies the angle in ° by which the traces must be orthogonal; see
-[`traces_are_orthogonal`](@ref)
+[`are_orthogonal`](@ref)
 
 !!! note
     If `incidence` is 0° or 90° (the direction is vertical), then the choice

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -115,6 +115,275 @@ transverse traces in the modified array `t′`
 rotate_to_gcp(args...; kwargs...) = rotate_to_gcp!(deepcopy.(args)...; kwargs...)
 
 """
+    rotate_to_azimuth_incidence!(t1, t2, t3, azimuth, incidence[; tol]) -> x, y, z
+
+Rotate a mutually-orthogonal set of traces `t1`, `t2` and `t3` such that the trace
+`x` points along the direction defined by `azimuth`, `y` points perpendicular to `x`
+and has components only in the direction along `azimuth` and the vertical;
+`z` is perpendicular to both and lies in the horizontal plane.
+`x`, `y` and `z` form a right-handed set and are commonly known as L, Q and T
+respectively.  (See [`rotate_to_lqt!`](@ref).)
+
+Note that in this form, the underlying data and metadata in the input traces is
+altered, and the returned traces point to the same data as the input traces, but
+possibly in a different order.  Use [`rotate_to_azimuth_incidence`](@ref) to return
+copies of the traces and leave the original traces unmodified.
+
+See also: [`rotate_to_azimuth_incidence`](@ref), [`rotate_to_gcp!`](@ref),
+[`rotate_to_lqt!`](@ref), [`rotate_through`](@ref)
+"""
+function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::AbstractTrace,
+        azimuth=backazimuth(t1)+180, incidence=incidence(t1);
+        tol=_angle_tol(t1, t2, t3))
+    # Check angles
+    0 <= incidence <= 180 ||
+        throw(ArgumentError("incidence must be in the range 0 to 180"))
+    # Check traces
+    if !are_orthogonal(t1, t2, t3)
+        throw(ArgumentError("traces must be orthogonal"))
+    elseif !(axes(trace(t1)) == axes(trace(t2)) == axes(trace(t3)))
+        throw(ArgumentError("traces must all be the same length"))
+    elseif !(eltype(t1) == eltype(t2) == eltype(t3))
+        throw(ArgumentError("traces must all have the same element type"))
+    elseif !(times(t1) == times(t2) == times(t3))
+        throw(ArgumentError("traces must all have the same start time and sampling interval"))
+    end
+    # Sort traces so that we start with a right-handed set
+    x, y, z, perm = sort_traces_right_handed(t1, t2, t3)
+
+    # Component directions
+    uˣ, uʸ, uᶻ = _direction_vector.((x, y, z))
+
+    # New x direction is like L
+    azˣ, incˣ = mod(azimuth, 360), incidence
+    uˣ′ = _direction_vector(azˣ, incˣ)
+
+    # New y is 'Q' component, accounting for flip of direction
+    azʸ, incʸ = if incidence >= 90
+        azimuth, incidence - 90
+    else
+        mod(azimuth + 180, 360), 90 - incidence
+    end
+    uʸ′ = _direction_vector(azʸ, incʸ) # Like Q
+
+    # New z is 'T' component
+    azᶻ = mod(azimuth + 90, 360)
+    incᶻ = 90
+    uᶻ′ = uˣ′ × uʸ′
+
+    rotation_matrix = _construct_rotation_matrix(uˣ, uʸ, uᶻ, uˣ′, uʸ′, uᶻ′)
+
+    # Do the rotation
+    tx = trace(x)
+    ty = trace(y)
+    tz = trace(z)
+    @inbounds for i in eachindex(tx)    
+        tx[i], ty[i], tz[i] = rotation_matrix*StaticArrays.@SVector[tx[i], ty[i], tz[i]]
+    end
+
+    # Set headers
+    x.sta.azi, x.sta.inc = azˣ, incˣ
+    y.sta.azi, y.sta.inc = azʸ, incʸ
+    z.sta.azi, z.sta.inc = azᶻ, incᶻ
+
+    for (i, t) in enumerate((x, y, z))
+        code = if isapprox(t.sta.inc, 0, atol=tol)
+            "Z"
+        elseif isapprox(t.sta.inc, 90, atol=tol) && isapprox(t.sta.azi, 0, atol=tol)
+            "N"
+        elseif isapprox(t.sta.inc, 90, atol=tol) && isapprox(t.sta.azi, 90, atol=tol)
+            "E"
+        else
+            string(i)
+        end
+
+        if _is_rotatable_seed_channel_name(t.sta.cha)
+            cha = t.sta.cha
+            t.sta.cha = cha[1:2] * code
+        else
+            t.sta.cha = code
+        end
+    end
+
+    x, y, z
+end
+
+"""
+    rotate_to_lqt!(t1, t2, t3[, azimuth, [incidence]]; [tol]) -> L, Q, T
+
+Rotate the three traces `t1`, `t2` and `t3` in place, and return them in the
+order `L`, `Q` and `T`, forming a right-handed set.
+
+The `L` trace records positive motion along the event-receiver direction,
+defined by the local `azimuth` at the receiver (i.e., backazimuth + 180°)
+and `incidence` angle (measured downwards away from the positive upwards direction).
+
+The `T` direction is transverse to `L`, such that when looking along the
+direction towards the station, `T` is on the right and lies in the horizontal plane.
+
+The `Q` direction is perpendicular to both, lying in the saggital plane, with
+some component in the vertical direction.
+
+If `azimuth` and `inclination` are not passed in explicitly, then they are
+determined using the event-station geometry.  This is only possible for
+`Trace`s in Cartesian geometry, since `inclination` is not well-determined in
+a geographic system.  For the Cartesian case, we assume straight-line paths
+between event and receiver.
+
+`tol` specifies the angle in ° by which the traces must be orthogonal; see
+[`traces_are_orthogonal`](@ref)
+
+!!! note
+    If `incidence` is 0° or 90° (the direction is vertical), then the choice
+    of `Q` and `T` is arbitrary and simply chosen such that `Q` points along
+    the local `azimuth`.
+
+# Diagram
+## Plan view
+```
+ ⋆ (event)       North
+  `                ↑
+    `              |
+      `            |
+        `
+          ∇ (station) 
+         ⊙ `
+      -  Q   `
+    ↙          ↘
+   T            L
+```
+
+## Side view
+```
+                 Q
+                 ↑
+ Up               |
+ ↑                 |
+ |                  |      __ → L
+ |      (station)  ∇ ⊙__--- 
+             .__--   T
+        .__--
+    __--
+  ⋆ (event)
+```
+
+# Examples
+```
+julia> e, n, z = sample_data(:regional)[1:3];
+
+julia> azi = azimuth(e) + 180
+216.85858118935954
+
+julia> inc = 30; # Determined from other calculation
+
+julia> l, q, t = rotate_to_lqt!(e, n, z, azi, inc)
+(Seis.Trace(.ELK..1: delta=0.025, b=-5.000015, nsamples=12000), Seis.Trace(.ELK..2: delta=0.025, b=-5.000015, nsamples=12000), Seis.Trace(.ELK..T: delta=0.025, b=-5.000015, nsamples=12000))
+
+julia> l.sta.azi, l.sta.inc, l.sta.cha
+(216.85858f0, 30.0f0, "1")
+
+julia> t.sta.cha
+"T"
+
+julia> l == e, q == n, t == z # Original traces are modified and returned in a possibly different order
+(true, true, true)
+```
+"""
+function rotate_to_lqt!(t1, t2, t3, azimuth=backazimuth(t1)+180, incidence=incidence(t1);
+        tol=_angle_tol(t1, t2, t3))
+    l, q, t = rotate_to_azimuth_incidence!(t1, t2, t3, azimuth, incidence; tol=tol)
+    if _is_rotatable_seed_channel_name(l.sta.cha)
+        cha = l.sta.cha
+        t.sta.cha = cha[1:2] * "T"
+    else
+        t.sta.cha = "T"
+    end
+    l, q, t
+end
+
+"""
+    rotate_to_lqt(t1, t2, t3[; tol]) -> l, q, t
+
+Copying version of [`rotate_to_lqt!`](@ref).
+"""
+rotate_to_lqt(t1, t2, t3; kwargs...) = rotate_to_lqt!(deepcopy.((t1, t2, t3))...; kwargs...)
+
+"""
+    rotate_to_enz!(t1, t2, t3[; tol]) -> e, n, z
+
+Rotate three orthogonal traces `t1`, `t2` and `t3` in place so that they point
+east (`e`), north (`n`) and vertically (`z`).
+
+`e`, `n` and `z` are bindings to the same data as `t1`, `t2` and `t3`,
+but they may not be returned in the same order as passed in if the original
+set of traces are not given as a right-handed set.
+"""
+function rotate_to_enz!(t1, t2, t3; tol=_angle_tol(t1, t2, t3))
+    e, n, z = rotate_to_azimuth_incidence!(t1, t2, t3, 0, 90; tol=tol)
+    for (t, cha) in zip((e, n, z), ("E", "N", "Z"))
+        if _is_rotatable_seed_channel_name(t.sta.cha)
+            t.sta.cha = t.sta.cha[1:2] * cha
+        else
+            t.sta.cha = cha
+        end
+    end
+    e, n, z
+end
+
+"""
+    rotate_to_enz(t1, t2, t3[; tol]) -> e, n, z
+
+Copying version of [`rotate_to_enz!`](@ref).
+"""
+rotate_to_enz(t1, t2, t3; kwargs...) = rotate_to_enz!(deepcopy.((t1, t2, t3))...; kwargs...)
+
+"""
+    sort_traces_right_handed(t1, t2, t3) -> x, y, z, perm
+
+Sort the traces `t1`, `t2` and `t3` such that they form a right-handed set;
+requiring the traces to be mutually orthogonal.  The direction of `x`, `y` and `z`
+are arbitrary.  `perm` is a length-three tuple containing the indices (from 1 to 3)
+of the new order of traces, such that `x` is `(t1, t2, t3)[perm[1]]` and so on.
+
+# Example
+```
+julia> e, n, z = sample_data(:regional)[1:3];
+
+julia> e.sta.cha, n.sta.cha, z.sta.cha # Confirm the order
+("e", "n", "z")
+
+julia> u, v, w, perm = Seis.sort_traces_right_handed(n, e, z); # A left-handed arrangement
+
+julia> [u, v, w].sta.cha
+3-element Vector{String}:
+ "n"
+ "z"
+ "e"
+
+julia> [n, e, z][[perm...]] # Indexing by perm gives us the new order
+3-element Vector{Trace{Float32, Vector{Float32}, Seis.Geographic{Float32}}}:
+ Seis.Trace(.ELK..n: delta=0.025, b=-5.000015, nsamples=12000)
+ Seis.Trace(.ELK..z: delta=0.025, b=-5.000015, nsamples=12000)
+ Seis.Trace(.ELK..e: delta=0.025, b=-5.000015, nsamples=12000)
+```
+"""
+function sort_traces_right_handed(t1::AbstractTrace, t2::AbstractTrace, t3::AbstractTrace;
+        tol=_angle_tol(t1, t2, t3))
+    are_orthogonal(t1, t2, t3; tol=tol) ||
+        throw(ArgumentError("traces must be orthogonal"))
+    # If t1, t2, t3 form a right-handed set and 𝐮₁, 𝐮₂ and 𝐮₃ are the unit vectors
+    # pointing along the channels, then 𝐮₁×𝐮₂ = 𝐮₃.  Otherwise, 𝐮₁×𝐮₂ = –𝐮₃.
+    u1, u2, u3 = _direction_vector.((t1, t2, t3))
+    u1_cross_u2 = u1 × u2
+    # Only compare to the nearest degree
+    if _directions_are_parallel(u1_cross_u2, u3, 1)
+        return t1, t2, t3, (1, 2, 3)
+    else
+        return t1, t3, t2, (1, 3, 2)
+    end
+end
+
+"""
     _is_rotatable_seed_channel_name(s) -> ::Bool
 
 Return `true` if `s` is a string conforming to SEED channel naming conventions which
@@ -124,3 +393,24 @@ describes a channel for which it makes sense to rotate a matching pair of these 
 - https://ds.iris.edu/ds/nodes/dmc/data/formats/seed-channel-naming/
 """
 _is_rotatable_seed_channel_name(s) = occursin(r"^[FGDCESHBMLVURPTQAO][HLGMNAFJPSXYZ][ZNEABCTR123UVW]$", s)
+
+"""
+    _construct_rotation_matrix(uˣ, uʸ, uᶻ, uˣ′, uʸ′, uᶻ′) -> R
+
+Construct the rotation matrix `R` which maps the basis formed by `(uˣ, uʸ, uᶻ)`
+to the new basis formed by `(uˣ′, uʸ′, uᶻ′)`, where each `uⁱ` is a single unit
+vector.
+"""
+function _construct_rotation_matrix(uˣ, uʸ, uᶻ, uˣ′, uʸ′, uᶻ′)
+    # If `R¹` is formed by placing `uˣ`, `uʸ` and `uᶻ` in the columns of a matrix, and
+    # likewise `R²` for the second basis set, and `R` is the rotation matrix,
+    # then `R * R¹ = R²` and `R = inv(R¹) * R²`.  Thankfully `inv(R¹)` is just `(R¹)ᵀ`
+    # because the vectors are orthogonal, thus we avoid doing `R¹\R²`.
+    R¹ = StaticArrays.@SMatrix[uˣ[1] uʸ[1] uᶻ[1]
+                               uˣ[2] uʸ[2] uᶻ[2]
+                               uˣ[3] uʸ[3] uᶻ[3]]
+    R² = StaticArrays.@SMatrix[uˣ′[1] uʸ′[1] uᶻ′[1]
+                               uˣ′[2] uʸ′[2] uᶻ′[2]
+                               uˣ′[3] uʸ′[3] uᶻ′[3]]
+    transpose(R²)*R¹
+end

--- a/src/util.jl
+++ b/src/util.jl
@@ -36,6 +36,52 @@ which is the maximum tolerance for all arguments.
 _angle_tol(x, y...) = max(_angle_tol(x), _angle_tol(y...))
 
 """
+    are_orthogonal(sta1, sta2[, sta3]; tol) -> ::Bool
+    are_orthogonal(t1, t2[, t3]; tol) -> ::Bool
+
+Return `true` if `Station`s `sta1` and `sta2` are orthogonal to each other, or
+if `sta1`, `sta2` and `sta3` form a mutually-orthogonal set.
+
+The comparison can also be performed on `Trace`s in the second form.
+
+Directions are considered orthogonal if they differ from 90° by less than
+`tol`°, with a default value given by [`_angle_tol`](@ref).
+
+# Examples
+```
+julia> e, n, z = sample_data(:regional)[1:3];
+
+julia> are_orthogonal(e, n)
+true
+
+julia> are_orthogonal(e, n, z)
+true
+
+julia> are_orthogonal(Station(azi=0, inc=90), Station(azi=91, inc=90))
+false
+```
+"""
+function are_orthogonal(s1::Station, s2::Station; tol=_angle_tol(s1, s2))
+    u1, u2 = _direction_vector.((s1, s2))
+    _directions_are_orthogonal(u1, u2, tol)
+end
+
+are_orthogonal(t1::AbstractTrace, t2::AbstractTrace; tol=_angle_tol(t1, t2)) =
+    are_orthogonal(t1.sta, t2.sta; tol=tol)
+
+function are_orthogonal(s1::Station, s2::Station, s3::Station;
+        tol=_angle_tol(s1, s2, s3))
+    u1, u2, u3 = _direction_vector.((s1, s2, s3))
+    for (u, v) in ((u1, u2), (u2, u3), (u3, u1))
+        _directions_are_orthogonal(u, v, tol) || return false
+    end
+    true
+end
+
+are_orthogonal(t1::AbstractTrace, t2::AbstractTrace, t3::AbstractTrace; kwargs...) =
+    are_orthogonal(t1.sta, t2.sta, t3.sta; kwargs...)
+
+"""
     dates(t) -> date_range
 
 Return a `date_range` which contains the dates for each sample of `t`, so long
@@ -559,11 +605,104 @@ julia> trace(t)
 trace(t::AbstractTrace) = t.t
 
 """
-    traces_are_orthogonal(t1::Trace, t2::Trace; tol=eps()) -> ::Bool
+    traces_are_orthogonal(t1, t2[; tol] -> ::Bool
 
 Return `true` if the two traces `t1` and `t2` have component azimuths
 90° apart.  Set the tolerance of the comparison with `tol`.
+
+!!! note
+    This function simply compares component azimuths and ignores component
+    inclinations entirely.
+
+!!! note
+    This function will be removed in a future major version of the package;
+    use [`are_orthogonal`](@ref) instead.
 """
-traces_are_orthogonal(t1::AbstractTrace, t2::AbstractTrace;
-                      tol=max(_angle_tol(t1), _angle_tol(t1))) =
+traces_are_orthogonal(t1, t2; tol=_angle_tol(t1, t2)) =
     isapprox(abs(angle_difference(t1.sta.azi, t2.sta.azi)), 90, atol=tol)
+
+"""
+    _direction_vector(azi, inc) -> [x, y, z]
+
+Return a vector containing the components of a vector pointing along azimuth `azi`
+and inclination `inc`.  Azimuth is measured from north (y) towards east (x), whilst
+inclination is measured downwards from upwards (z).  All angles in degrees.
+"""
+function _direction_vector(azi, inc)
+    sina, cosa = sincosd(azi)
+    sini, cosi = sincosd(inc)
+    StaticArrays.@SVector[sina*sini, cosa*sini, cosi]
+end
+
+"""
+    _direction_vector(station) -> [x, y, z]
+    _direction_vector(trace) -> [x, y, z]
+
+Return the components of a vector pointing along the channel orientation for
+a `station` or `trace`.
+"""
+_direction_vector(s::Station) = _direction_vector(s.azi, s.inc)
+_direction_vector(t::AbstractTrace) = _direction_vector(t.sta)
+
+"""
+    _directions_are_orthogonal(u, v, tol) -> ::Bool
+
+Return `true` if unit vectors `u` and `v` are orthogonal within tolerance `tol`°.
+
+!!! note
+    No check is made that `u` and `v` are normalised, nor any normalisation performed,
+    hence `u` and `v` must already be normalised when passed in.
+"""
+function _directions_are_orthogonal(u, v, tol)
+    _, θ = _u_dot_v_and_theta(u, v)
+    abs(θ - 90) <= tol
+end
+
+"""
+    _directions_are_parallel(u, v, tol) -> ::Bool
+
+Return `true` if direction unit vectors `u` and `v` point in the same direction
+within an angle of `tol`°.
+
+!!! note
+    No check is made that `u` and `v` are normalised, nor any normalisation performed,
+    hence `u` and `v` must already be normalised when passed in.
+"""
+function _directions_are_parallel(u, v, tol)
+    _, θ = _u_dot_v_and_theta(u, v)
+    θ <= tol
+end
+
+"""
+    _directions_are_antiparallel(u, v, tol) -> ::Bool
+
+Return `true` if direction unit vectors `u` and `v` point in the opposite direction
+within an angle of `tol`°.
+
+!!! note
+    No check is made that `u` and `v` are normalised, nor any normalisation performed,
+    hence `u` and `v` must already be normalised when passed in.
+"""
+function _directions_are_antiparallel(u, v, tol)
+    _, θ = _u_dot_v_and_theta(u, v)
+    abs(θ - 180) <= tol
+end
+
+"""
+    _u_dot_v_and_theta(u, v) -> u⋅v, θ
+
+Return the dot product between vectors `u` and `v`, `u⋅v`, and the angle between them
+`θ` in degrees.
+
+!!! note
+    No check is made that `u` and `v` are normalised, nor any normalisation performed,
+    hence `u` and `v` must already be normalised when passed in.
+"""
+function _u_dot_v_and_theta(u, v)
+    u_dot_v = u ⋅ v
+    # Return θ in degrees since angle tolerances in degrees may be very small and
+    # lose precision in conversion to radians.
+    # Enforce u⋅v to be in range (-1, 1) to avoid errors in acos due to round-off.
+    θ = acosd(clamp(u_dot_v, -1, 1))
+    u_dot_v, θ
+end

--- a/src/util.jl
+++ b/src/util.jl
@@ -19,11 +19,21 @@ end
 
 Return an appropriate tolerance for `x` (a floating point type, `AbstractTrace` or
 `Station`) to use in comparisons of angular quantities in °.  Angles which are `tol`°
-apart can be considered identical.
+or less apart can be considered identical.
 """
-_angle_tol(T::DataType) = √eps(T)
+_angle_tol(x) = throw(ArgumentError("must call _angle_tol with a type, Trace or Station"))
+# Numerical errors accumulate too fast for Float64, so make its tolerance larger
+_angle_tol(T::DataType) = T == Float64 ? 1000*√eps(T) : √eps(T)
 _angle_tol(::Station{T}) where T = _angle_tol(T)
 _angle_tol(t::AbstractTrace) = _angle_tol(t.sta)
+
+"""
+    _angle_tol(x, y...) -> tol
+
+Return an appropriate tolerance for a set of values or types `x` and `y...`,
+which is the maximum tolerance for all arguments.
+"""
+_angle_tol(x, y...) = max(_angle_tol(x), _angle_tol(y...))
 
 """
     dates(t) -> date_range

--- a/src/util.jl
+++ b/src/util.jl
@@ -48,7 +48,7 @@ if `sta1`, `sta2` and `sta3` form a mutually-orthogonal set.
 The comparison can also be performed on `Trace`s in the second form.
 
 Directions are considered orthogonal if they differ from 90° by less than
-`tol`°, with a default value given by [`_angle_tol`](@ref).
+`tol`°, with a default value given by [`Seis._angle_tol`](@ref).
 
 # Examples
 ```

--- a/src/util.jl
+++ b/src/util.jl
@@ -22,8 +22,11 @@ Return an appropriate tolerance for `x` (a floating point type, `AbstractTrace` 
 or less apart can be considered identical.
 """
 _angle_tol(x) = throw(ArgumentError("must call _angle_tol with a type, Trace or Station"))
-# Numerical errors accumulate too fast for Float64, so make its tolerance larger
-_angle_tol(T::DataType) = T == Float64 ? 1000*√eps(T) : √eps(T)
+# Numerical errors accumulate too fast for Float64, so make its tolerance larger,
+# whilst for Float16 errors are very large anyway
+_angle_tol(T::DataType) = T == Float64 ? 1000*√eps(T) : 
+                          T == Float16 ? 10*√eps(T) :
+                               √eps(T)
 _angle_tol(::Station{T}) where T = _angle_tol(T)
 _angle_tol(t::AbstractTrace) = _angle_tol(t.sta)
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -676,6 +676,7 @@ within an angle of `tol`°.
     hence `u` and `v` must already be normalised when passed in.
 """
 function _directions_are_parallel(u, v, tol)
+    u == v && return true
     _, θ = _u_dot_v_and_theta(u, v)
     θ <= tol
 end
@@ -691,6 +692,7 @@ within an angle of `tol`°.
     hence `u` and `v` must already be normalised when passed in.
 """
 function _directions_are_antiparallel(u, v, tol)
+    u == -v && return true
     _, θ = _u_dot_v_and_theta(u, v)
     abs(θ - 180) <= tol
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -642,6 +642,19 @@ function _direction_vector(azi, inc)
 end
 
 """
+    _direction_to_azimuth_incidence(u) -> azi, inc
+
+Return the azimuth `azi` and incidence `inc` in the Seis frame
+defined by the vector `u`, which need not be normalised.
+Angles are in degrees.
+"""
+function _direction_to_azimuth_incidence(u)
+    azi = mod(atand(u[1], u[2]), 360)
+    inc = atand(sqrt(u[1]^2 + u[2]^2), u[3])
+    azi, inc
+end
+
+"""
     _direction_vector(station) -> [x, y, z]
     _direction_vector(trace) -> [x, y, z]
 

--- a/src/util.jl
+++ b/src/util.jl
@@ -123,6 +123,8 @@ julia> t = sample_data(); t.evt.time
 julia> startdate(t)
 1981-03-29T10:39:06.66
 ```
+
+See also: [`enddate`](@ref).
 """
 startdate(t::AbstractTrace) = ((b, delta) = _check_date_b_delta(t); t.evt.time + b)
 
@@ -143,6 +145,8 @@ julia> t = sample_data(); t.evt.time
 julia> enddate(t)
 1981-03-29T10:39:16.65
 ```
+
+See also: [`startdate`](@ref).
 """
 enddate(t::AbstractTrace) = ((b, delta) = _check_date_b_delta(t); t.evt.time + b + (nsamples(t)-1)*delta)
 
@@ -176,6 +180,8 @@ julia> t = Trace(-3, 0.01, rand(20)) # Set start time to -3;
 julia> starttime(t)
 -3.0
 ```
+
+See also: [`endtime`](@ref).
 """
 starttime(t::AbstractTrace) = t.b
 
@@ -191,6 +197,8 @@ julia> t = Trace(5, 1, 3); # 3 samples at 1 Hz, starting at 5 s
 julia> endtime(t)
 7.0
 ```
+
+See also: [`starttime`](@ref).
 """
 endtime(t::AbstractTrace) = t.b + (nsamples(t) - 1)*t.delta
 
@@ -612,11 +620,7 @@ Return `true` if the two traces `t1` and `t2` have component azimuths
 
 !!! note
     This function simply compares component azimuths and ignores component
-    inclinations entirely.
-
-!!! note
-    This function will be removed in a future major version of the package;
-    use [`are_orthogonal`](@ref) instead.
+    inclinations entirely; use [`are_orthogonal`](@ref) instead.
 """
 traces_are_orthogonal(t1, t2; tol=_angle_tol(t1, t2)) =
     isapprox(abs(angle_difference(t1.sta.azi, t2.sta.azi)), 90, atol=tol)

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -34,24 +34,30 @@ azimuth_inclination(v) = atand(v[1], v[2]), acosd(v[3])
 "Get a unit vector from an azimuth and inclination"
 unit_vector(azi, inc) = @SVector[sind(azi)*sind(inc), cosd(azi)*sind(inc), cosd(inc)]
 
-"Create a randomly-oriented set of traces making up a right-handed set"
+"""
+Create a randomly-oriented set of traces making up a right-handed set,
+with 
+"""
 function random_basis_traces(T=Float64, P=Seis.Geographic{T})
     x, y, z = [Trace{T, Vector{T}, P}(0, 1, 0) for _ in 1:3]
     x.sta.cha, y.sta.cha, z.sta.cha = "X", "Y", "Z"
     # Do vector creation and calculation in Float64
-    # A random unit vector give the first trace's direction
+    # A random unit vector gives the first trace's direction
     ux = random_unit_vector(Float64)
     # Then find an orthogonal vector
     v = random_unit_vector(Float64)
     uy = normalize(ux × v)
     # Third direction gives right-handed set x, y, z
     uz = ux × uy
-    # Only round to lower precision at this point
+    # Only round from Float64 to lower precision at this point during
+    # auto-conversion to T
     x.sta.azi, x.sta.inc = azimuth_inclination(ux)
     y.sta.azi, y.sta.inc = azimuth_inclination(uy)
     z.sta.azi, z.sta.inc = azimuth_inclination(uz)
     x, y, z
 end
+random_basis_traces(::Type{Trace{T}}) where T = random_basis_traces(T, Seis.Geographic{T})
+random_basis_traces(::Type{CartTrace{T}}) where T = random_basis_traces(T, Seis.Cartesian{T})
 
 "Return a vector and one randomly deviated away from it by `θ`°."
 function vector_and_deviated_vector(T, θ)

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -65,7 +65,8 @@ Fill the traces `t1`, `t2` and `t3` (an orthogonal set) with `data_l`, `data_q` 
 respectively along the L, Q and T directions defined by `azimuth` and `inclination`.
 """
 function project_onto_traces!(t1, t2, t3, azimuth, inclination, data_l, data_q, data_t)
-    @assert length(data_l) == length(data_q) == length(data_t)
+    length(data_l) == length(data_q) == length(data_t) ||
+        throw(ArgumentError("all data vectors must be the same length"))
     npts = length(data_l)
 
     # Get unit vector for each of L, Q and T

--- a/test/TestHelpers.jl
+++ b/test/TestHelpers.jl
@@ -1,0 +1,69 @@
+"""
+Module `TestHelpers` contains helper functions for the package's tests.
+
+If you are running individual tests, include this file and do `using .TestHelpers`.
+"""
+module TestHelpers
+
+using LinearAlgebra: ×
+using Seis
+import Rotations
+using StaticArrays: SVector, @SVector
+
+export
+    azimuth_inclination,
+    compare_copy_modify_func,
+    random_basis_traces,
+    random_unit_vector,
+    unit_vector,
+    vector_and_deviated_vector
+
+"Make sure that copying and in-place versions respectively do not and do modify the trace"
+function compare_copy_modify_func(f, f!, args...; kwargs...)
+    t = Trace(100rand(), rand(), rand(100))
+    t′ = deepcopy(t)
+    f(t, args...; kwargs...) == f!(t′, args...; kwargs...) && t != t′
+end
+
+"Randomly oriented unit vector"
+random_unit_vector(T=Float64) = normalize(rand(SVector{3,T}) .- one(T)/2)
+
+"Return the azimuth and inclination in the Seis frame from a unit vector"
+azimuth_inclination(v) = atand(v[1], v[2]), acosd(v[3])
+
+"Get a unit vector from an azimuth and inclination"
+unit_vector(azi, inc) = @SVector[sind(azi)*sind(inc), cosd(azi)*sind(inc), cosd(inc)]
+
+"Create a randomly-oriented set of traces making up a right-handed set"
+function random_basis_traces(T=Float64, P=Seis.Geographic{T})
+    x, y, z = [Trace{T, Vector{T}, P}(0, 1, 0) for _ in 1:3]
+    x.sta.cha, y.sta.cha, z.sta.cha = "X", "Y", "Z"
+    # Do vector creation and calculation in Float64
+    # A random unit vector give the first trace's direction
+    ux = random_unit_vector(Float64)
+    # Then find an orthogonal vector
+    v = random_unit_vector(Float64)
+    uy = normalize(ux × v)
+    # Third direction gives right-handed set x, y, z
+    uz = ux × uy
+    # Only round to lower precision at this point
+    x.sta.azi, x.sta.inc = azimuth_inclination(ux)
+    y.sta.azi, y.sta.inc = azimuth_inclination(uy)
+    z.sta.azi, z.sta.inc = azimuth_inclination(uz)
+    x, y, z
+end
+
+"Return a vector and one randomly deviated away from it by `θ`°."
+function vector_and_deviated_vector(T, θ)
+    v = random_unit_vector()
+    w = random_unit_vector()
+    # Vector normal to v (and w)
+    u = normalize(v × w)
+    # Rotate about this new vector u
+    rot = Rotations.AngleAxis(deg2rad(θ), u...)
+    v′ = rot*v
+    v, v′
+end
+vector_and_deviated_vector(θ) = vector_and_deviated_vector(Float64, θ)
+
+end # module

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -3,7 +3,7 @@ using Test
 using Seis
 using LinearAlgebra: ×
 
-using .TestHelpers
+import .TestHelpers
 
 trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x, y), (z, y, x)
 
@@ -88,9 +88,9 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
         @testset "$([traces...].sta.cha)" for traces in trace_permutations(x, y, z)
             @test are_orthogonal(traces..., tol=1)
             x′, y′, z′ = sort_traces_right_handed(traces...)
-            ux′ = unit_vector(x′.sta.azi, x′.sta.inc)
-            uy′ = unit_vector(y′.sta.azi, y′.sta.inc)
-            uz′ = unit_vector(z′.sta.azi, z′.sta.inc)
+            ux′ = TestHelpers.unit_vector(x′.sta.azi, x′.sta.inc)
+            uy′ = TestHelpers.unit_vector(y′.sta.azi, y′.sta.inc)
+            uz′ = TestHelpers.unit_vector(z′.sta.azi, z′.sta.inc)
             @test ux′ × uy′ ≈ uz′
         end
     end
@@ -243,15 +243,15 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
 
         @testset "Random trace orientation" begin
             T = Float64
-            x, y, z = random_basis_traces(T)
+            x, y, z = TestHelpers.random_basis_traces(T)
             # Add a single data point which we will modify
             push!(trace(x), 0)
             push!(trace(y), 0)
             push!(trace(z), 0)
 
             @testset "On L" begin
-                v = random_unit_vector(T)
-                azimuth, incidence = azimuth_inclination(v)
+                v = TestHelpers.random_unit_vector(T)
+                azimuth, incidence = TestHelpers.azimuth_inclination(v)
                 @info "TODO: Add tests for trace rotation"
             end
 
@@ -261,7 +261,7 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
 
     @testset "rotate_to_lqt" begin
         @testset "$T" for T in (Float32, Float64)
-            x, y, z = random_basis_traces(T)
+            x, y, z = TestHelpers.random_basis_traces(T)
             @info "TODO: Add tests for `rotate_to_lqt` and implement for `CartTrace`"
         end
     end

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -342,6 +342,17 @@ angles_are_same(a, b, tol=Seis._angle_tol(typeof(float(a)), typeof(float(b)))) =
                     end
                 end
             end
+
+            @testset "In-place v copying" begin
+                e, n, z = sample_data(:local)[1:3]
+                e′, n′, z′ = deepcopy.((e, n, z))
+                az, inc = 45, 10
+                @test rotate_to_azimuth_incidence(e, n, z, az, inc) ==
+                    rotate_to_azimuth_incidence!(e′, n′, z′, az, inc)
+                @test e′ != e
+                @test n′ != n
+                @test z′ != z
+            end
         end
 
         @testset "Random trace orientation" begin

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -267,9 +267,41 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
     end
 
     @testset "rotate_to_enz" begin
-        @testset "$T" for T in (Float32, Float64)
-            x, y, z = random_basis_traces(T)
-            @info "TODO: Add tests for `rotate_to_enz`"
+        @testset "ENZ" begin
+            @testset "$T" for T in (Trace, CartTrace)
+                @testset "$(T{F})" for F in (Float16, Float32, Float64)
+                    e, n, z = t = [T{F}(0, 1, 0) for _ in 1:3]
+                    t.sta.azi = 90, 0, 0
+                    t.sta.inc = 90, 90, 0
+                    t.sta.cha = "E", "N", "Z"
+                    push!.(trace.(t), 1:3)
+                    @test rotate_to_enz(e, n, z) == (e, n, z)
+                    @test rotate_to_enz(n, e, z) == (e, n, z)
+                    @test rotate_to_enz(z, n, e) == (e, n, z)
+                    @test rotate_to_enz(z, e, n) == (e, n, z)
+                    e′, n′, z′ = t′ = deepcopy(t)
+                    @test rotate_to_enz(e′, n′, z′) == (e, n, z)
+                    @test rotate_to_enz(n′, e′, z′) == (e, n, z)
+                    @test rotate_to_enz(z′, n′, e′) == (e, n, z)
+                    @test rotate_to_enz(z′, e′, n′) == (e, n, z)
+                end
+            end
         end
+
+        @testset "Random" begin
+            @testset "$TR" for TR in (Trace, CartTrace)
+                @testset "$T" for T in (Float32, Float64)
+                    x, y, z = TestHelpers.random_basis_traces(TR{T})
+                    @info "TODO: Add tests for `rotate_to_enz`"
+                end
+            end
+        end
+    end
+
+    @testset "_is_rotatable_seed_channel_name" begin
+        @test Seis._is_rotatable_seed_channel_name("BH1") == true
+        @test Seis._is_rotatable_seed_channel_name("LXU") == true
+        @test Seis._is_rotatable_seed_channel_name("BHL") == false
+        @test Seis._is_rotatable_seed_channel_name(missing) == false
     end
 end

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -2,6 +2,7 @@
 using Test
 using Seis
 using LinearAlgebra: ×
+using StaticArrays: SVector, @SVector
 
 import .TestHelpers
 
@@ -303,5 +304,15 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
         @test Seis._is_rotatable_seed_channel_name("LXU") == true
         @test Seis._is_rotatable_seed_channel_name("BHL") == false
         @test Seis._is_rotatable_seed_channel_name(missing) == false
+    end
+
+    @testset "_rotate_by_vector" begin
+        @test Seis._rotate_by_vector([0, 0, 1], [1, 0, 0], π/2) ≈ [0, -1, 0]
+        @test Seis._rotate_by_vector([0, 0, 1], [0, 1, 0], π/2) ≈ [1, 0, 0]
+        # No need to normalise the rotation vector
+        @test Seis._rotate_by_vector([0, 0, 1], [0, -10, 0], π/2) ≈ [-1, 0, 0]
+        v′ = Seis._rotate_by_vector(@SVector[0, 0, 1], @SVector[0, -10, 0], π/2)
+        @test v′ isa SVector
+        @test v′ ≈ @SVector[-1, 0, 0]
     end
 end

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -8,6 +8,9 @@ import .TestHelpers
 
 trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x, y), (z, y, x)
 
+angles_are_same(a, b, tol=Seis._angle_tol(typeof(float(a)), typeof(float(b)))) =
+    abs(Seis.angle_difference(a, b)) < tol
+
 @testset "Trace rotation" begin
     @testset "rotate_through" begin
         atol = 1e-6
@@ -29,8 +32,8 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
                         # pol - rot
                         @test all(isapprox.(
                             (trace(n′)[1], trace(e′)[1]), (cosd(pol - rot), sind(pol - rot)), atol=atol))
-                        @test n′.sta.azi ≈ mod(rot, 360) atol=atol
-                        @test e′.sta.azi ≈ mod(rot + 90, 360) atol=atol
+                        @test angles_are_same(n′.sta.azi, mod(rot, 360))
+                        @test angles_are_same(e′.sta.azi, mod(rot + 90, 360))
                     end
 
                     @testset "E to N" begin
@@ -38,8 +41,8 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
                         # Polarisation now as if pol + rot
                         @test all(isapprox.(
                             (trace(n′)[1], trace(e′)[1]), (cosd(pol + rot), sind(pol + rot)), atol=atol))
-                        @test n′.sta.azi ≈ mod(-rot, 360) atol=atol
-                        @test e′.sta.azi ≈ mod(90 - rot, 360) atol=atol
+                        @test angles_are_same(n′.sta.azi, mod(-rot, 360), atol)
+                        @test angles_are_same(e′.sta.azi, mod(90 - rot, 360), atol)
                     end
 
                     @testset "Reversible" begin
@@ -48,9 +51,9 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
                                 rotate_through(n, e, rot)..., -rot)
                             @test trace(n) ≈ trace(n″)
                             @test trace(e) ≈ trace(e″)
-                            @test n.sta.azi ≈ n″.sta.azi atol=atol
+                            @test angles_are_same(n.sta.azi, n″.sta.azi, atol)
                             @test n.sta.inc ≈ n″.sta.inc atol=atol
-                            @test e.sta.azi ≈ e″.sta.azi atol=atol
+                            @test angles_are_same(e.sta.azi, e″.sta.azi, atol)
                             @test e.sta.inc ≈ e″.sta.inc atol=atol
                         end
 
@@ -59,10 +62,10 @@ trace_permutations(x, y, z) = (x, y, z), (x, z, y), (y, x, z), (y, z, x), (z, x,
                                 rotate_through(n, e, rot)[[2,1]]..., rot)[[2,1]]
                             @test trace(n) ≈ trace(n″)
                             @test trace(e) ≈ trace(e″)
-                            @test n.sta.azi ≈ n″.sta.azi atol=atol
+                            @test angles_are_same(n.sta.azi, n″.sta.azi, atol)
                             @test n.sta.inc ≈ n″.sta.inc atol=atol
-                            @test e.sta.azi ≈ e″.sta.azi atol=atol
-                            @test e.sta.inc ≈ e″.sta.inc atol=atol 
+                            @test angles_are_same(e.sta.azi, e″.sta.azi, atol)
+                            @test e.sta.inc ≈ e″.sta.inc atol=atol
                         end
                     end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,12 +1,8 @@
 using Test
 using Seis
 
-"Make sure that copying and in-place versions respectively do not and do modify the trace"
-function compare_copy_modify_func(f, f!, args...; kwargs...)
-    t = Trace(100rand(), rand(), rand(100))
-    t′ = deepcopy(t)
-    f(t, args...; kwargs...) == f!(t′, args...; kwargs...) && t != t′
-end
+include("TestHelpers.jl")
+using .TestHelpers
 
 @testset "Seis" begin
     include("filtering.jl")

--- a/test/util.jl
+++ b/test/util.jl
@@ -25,17 +25,24 @@ using Seis
     end
 
     @testset "_angle_tol" begin
+        @testset "Not values" begin
+            @test_throws ArgumentError Seis._angle_tol(1)
+        end
         @testset "Not ints" begin
-            @test_throws MethodError Seis._angle_tol(1)
             @test_throws MethodError Seis._angle_tol(Int)
         end
-        @testset "$T" for T in (Float32, Float64)
+        @testset "$T" for T in (Float16, Float32, Float64)
             t = Trace{T,Vector{T},Seis.Geographic{T}}(0, 1, 0)
             sta = Station{T}()
-            tol = √eps(T)
+            tol = T == Float64 ? 1000*√eps(T) : √eps(T)
             @test Seis._angle_tol(T) === tol
             @test Seis._angle_tol(t) === tol
             @test Seis._angle_tol(sta) === tol
+        end
+        @testset "Multiple arguments" begin
+            @test Seis._angle_tol(Float16) == Seis._angle_tol(Float32, Float64, Float16)
+            @test Seis._angle_tol(Trace{Float32}(0, 1, 0), Trace{Float64}(0, 1, 0)) ==
+                Seis._angle_tol(Float32)
         end
     end
 

--- a/test/util.jl
+++ b/test/util.jl
@@ -38,7 +38,9 @@ using .TestHelpers
         @testset "$T" for T in (Float16, Float32, Float64)
             t = Trace{T,Vector{T},Seis.Geographic{T}}(0, 1, 0)
             sta = Station{T}()
-            tol = T == Float64 ? 1000*√eps(T) : √eps(T)
+            tol = T == Float64 ? 1000*√eps(T) :
+                  T == Float16 ? 10*√eps(T) :
+                  √eps(T)
             @test Seis._angle_tol(T) === tol
             @test Seis._angle_tol(t) === tol
             @test Seis._angle_tol(sta) === tol

--- a/test/util.jl
+++ b/test/util.jl
@@ -185,15 +185,15 @@ using .TestHelpers
                 @testset "Random orientations" begin
                     @testset "$T" for T in (Float16, Float32, Float64)
                         x, y, z = random_basis_traces(T)
-                        # Component shifted 5° in azimuth and inclination
+                        # x component rotated about vector between y and z by 5°
                         x′ = deepcopy(x)
-                        x′.sta.inc += 5
-                        if x′.sta.inc > 180
-                            x′.sta.inc = 180 - x′.sta.inc
-                            x′.sta.azi = mod(x′.sta.azi, + 185, 360)
-                        else
-                            x′.sta.azi = mod(x′.sta.azi + 5, 360)
-                        end
+                        x⃗ = Seis._direction_vector(x)
+                        y⃗ = Seis._direction_vector(y)
+                        z⃗ = Seis._direction_vector(z)
+                        k⃗ = normalize(y⃗ + z⃗)
+                        x⃗′ = Seis._rotate_by_vector(x⃗, k⃗, deg2rad(5))
+                        azi, inc = Seis._direction_to_azimuth_incidence(x⃗′)
+                        x′.sta.azi, x′.sta.inc = azi, inc
 
                         @testset "Pairs" begin
                             @test are_orthogonal(x, y)

--- a/test/util.jl
+++ b/test/util.jl
@@ -64,6 +64,18 @@ using .TestHelpers
         end
     end
 
+    @testset "_direction_to_azimuth_incidence" begin
+        atol = 1e-6
+        azi, inc = Seis._direction_to_azimuth_incidence([1, 0, 0])
+        @test azi ≈ 90 atol=atol
+        @test inc ≈ 90 atol=atol
+        azi, inc = Seis._direction_to_azimuth_incidence([0, -1, 0])
+        @test azi ≈ 180 atol=atol
+        @test inc ≈ 90 atol=atol
+        azi, inc = Seis._direction_to_azimuth_incidence([0, 0, -10])
+        @test inc ≈ 180 atol=atol
+    end
+
     @testset "_directions_are_orthogonal" begin
         @testset "$T" for T in (Float16, Float32, Float64)
             tol = Seis._angle_tol(T)


### PR DESCRIPTION
- Change tolerance for angle comparisons
- Add are_orthogonal to test for orthogonality of traces (and stations)
- Add some cross-references in docstrings
- WIP: add rotate_to_enz[!] and rotate_to_lqt[!]
- Allow _is_rotatable_seed_channel_name to cope with missing channel names
- _angle_tol: Fix tests for Float16
- _directions_are[anti]parallel: Ensure perfectly (anti)parallel vectors are identified
- TestHelpers: Add methods for creating randomly-oriented traces
- rotate_to_azimuth_incidence!: Check for channel orientation data
- Remove trailing whitespace from src/rotation.jl
- rotate_to_lqt: Correctly pass extra positional arguments
- rotate_to_enz!: Fix order of traces and hence rotation
- Qualify TestHelpers functions with the module name
- TestHelpers: Add project_onto_traces!
- Add more tests for rotate_to_enz!
- Add utility function _direction_to_azimuth_incidence
- Add utility function _rotate_by_vector
- Fix rotate_through[!] defining its convention
