### PR TITLE
New `FourierTrace` for frequency-domain traces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -19,6 +19,8 @@
     end to better match up with `Base.read`; and
   - now returns a `Trace{Float64, Vector{Float32}, Seis.Geographic{Float64}}`
     by default.
+- `plot`: The deprecated `picks` keyword argument has been removed in
+  favour of `show_picks`.
 
 ## New features
 - You can now write miniSEED files with `write_mseed`.

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.3.10"
 [deps]
 DSP = "717857b8-e6f2-59f4-9121-6e50c889abd2"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 Geodesics = "6aaf26a4-c633-11e8-35ae-8904cb805353"
 Glob = "c27321d9-0574-5035-807b-f59d2c89b15c"
 LibMseed = "1f77302d-495a-4b02-8d15-b81beb84162e"
@@ -16,6 +17,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 DSP = "0.6, 0.7"
+FFTW = "1"
 Glob = "1"
 LibMseed = "0.2.1"
 RecipesBase = "1"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -40,9 +40,9 @@ version = "1.16.1+1"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "9950387274246d08af38f6eef8cb5480862a435f"
+git-tree-sha1 = "2dd813e5f2f7eec2d1268c57cf2373d3ee91fcea"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "1.14.0"
+version = "1.15.1"
 
 [[ChangesOfVariables]]
 deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
@@ -52,21 +52,21 @@ version = "0.1.3"
 
 [[ColorSchemes]]
 deps = ["ColorTypes", "ColorVectorSpace", "Colors", "FixedPointNumbers", "Random"]
-git-tree-sha1 = "7297381ccb5df764549818d9a7d57e45f1057d30"
+git-tree-sha1 = "1fd869cc3875b57347f7027521f561cf46d1fcd8"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.18.0"
+version = "3.19.0"
 
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "63d1e802de0c4882c00aee5cb16f9dd4d6d7c59c"
+git-tree-sha1 = "eb7f0f8307f71fac7c606984ea5fb2817275d6e4"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.11.1"
+version = "0.11.4"
 
 [[ColorVectorSpace]]
 deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "SpecialFunctions", "Statistics", "TensorCore"]
-git-tree-sha1 = "3f1f500312161f1ae067abe07d13b40f78f32e07"
+git-tree-sha1 = "d08c20eef1f2cbc6e60fd3612ac4340b89fea322"
 uuid = "c3611d14-8923-5661-9e6a-0046d554d3a4"
-version = "0.9.8"
+version = "0.9.9"
 
 [[Colors]]
 deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
@@ -75,10 +75,10 @@ uuid = "5ae59095-9a9b-59fe-a467-6f913c188581"
 version = "0.12.8"
 
 [[Compat]]
-deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "b153278a25dd42c65abbf4e62344f9d22e59191b"
+deps = ["Dates", "LinearAlgebra", "UUIDs"]
+git-tree-sha1 = "924cdca592bc16f14d2f7006754a621735280b74"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.43.0"
+version = "4.1.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "Libdl"]
@@ -98,9 +98,9 @@ version = "0.5.7"
 
 [[DSP]]
 deps = ["Compat", "FFTW", "IterTools", "LinearAlgebra", "Polynomials", "Random", "Reexport", "SpecialFunctions", "Statistics"]
-git-tree-sha1 = "3e03979d16275ed5d9078d50327332c546e24e68"
+git-tree-sha1 = "3fb5d9183b38fdee997151f723da42fb83d1c6f2"
 uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
-version = "0.7.5"
+version = "0.7.6"
 
 [[DataAPI]]
 git-tree-sha1 = "fb5f5316dd3fd4c5e7c30a24d50643b73e37cd40"
@@ -109,9 +109,9 @@ version = "1.10.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "cc1a8e22627f33c789ab60b36a9132ac050bbf75"
+git-tree-sha1 = "d1fff3a548102f48987a52a2e0d114fa97d730f0"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.12"
+version = "0.18.13"
 
 [[DataValueInterfaces]]
 git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
@@ -126,10 +126,6 @@ uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
 deps = ["Mmap"]
 uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 
-[[Distributed]]
-deps = ["Random", "Serialization", "Sockets"]
-uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
-
 [[DocStringExtensions]]
 deps = ["LibGit2"]
 git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
@@ -138,9 +134,9 @@ version = "0.8.6"
 
 [[Documenter]]
 deps = ["ANSIColoredPrinters", "Base64", "Dates", "DocStringExtensions", "IOCapture", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "122d031e8dcb2d3e767ed434bc4d1ae1788b5a7f"
+git-tree-sha1 = "f7809f532671564e48cd81627ddcfb1ba670f87d"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.27.17"
+version = "0.27.19"
 
 [[Downloads]]
 deps = ["ArgTools", "LibCURL", "NetworkOptions"]
@@ -172,9 +168,9 @@ version = "4.4.0+0"
 
 [[FFTW]]
 deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
-git-tree-sha1 = "505876577b5481e50d089c1c68899dfb6faebc62"
+git-tree-sha1 = "90630efff0894f8142308e334473eba54c433549"
 uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
-version = "1.4.6"
+version = "1.5.0"
 
 [[FFTW_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -220,15 +216,15 @@ version = "3.3.6+0"
 
 [[GR]]
 deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "RelocatableFolders", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "af237c08bda486b74318c8070adb96efa6952530"
+git-tree-sha1 = "c98aea696662d09e215ef7cda5296024a9646c75"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.64.2"
+version = "0.64.4"
 
 [[GR_jll]]
 deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
-git-tree-sha1 = "cd6efcf9dc746b06709df14e462f0a3fe0786b1e"
+git-tree-sha1 = "3a233eeeb2ca45842fe100e0413936834215abf5"
 uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
-version = "0.64.2+0"
+version = "0.64.4+0"
 
 [[Geodesics]]
 git-tree-sha1 = "9fa57f6c5a42ef1f72539bc60c30dae18e5f32d4"
@@ -306,9 +302,9 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[InverseFunctions]]
 deps = ["Test"]
-git-tree-sha1 = "336cc738f03e069ef2cac55a104eb823455dca75"
+git-tree-sha1 = "b3364212fb5d870f724876ffcd34dd8ec6d98918"
 uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
-version = "0.1.4"
+version = "0.1.7"
 
 [[IrrationalConstants]]
 git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
@@ -439,9 +435,9 @@ version = "2.35.0+0"
 
 [[Libtiff_jll]]
 deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "LERC_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
-git-tree-sha1 = "c9551dd26e31ab17b86cbd00c2ede019c08758eb"
+git-tree-sha1 = "3eb79b0ca5764d4799c06699573fd8f533259713"
 uuid = "89763e89-9b03-5906-acba-b20f662cd828"
-version = "4.3.0+1"
+version = "4.4.0+0"
 
 [[Libuuid_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -455,9 +451,9 @@ uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
 deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
-git-tree-sha1 = "76c987446e8d555677f064aaac1145c4c17662f8"
+git-tree-sha1 = "09e4b894ce6a976c354a69041a04748180d43637"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.3.14"
+version = "0.3.15"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -507,9 +503,9 @@ uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
 
 [[MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "ba8c0f8732a24facba709388c74ba99dcbfdda1e"
+git-tree-sha1 = "4e675d6e9ec02061800d6cfb695812becbd03cdf"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "1.0.0"
+version = "1.0.4"
 
 [[NaNMath]]
 git-tree-sha1 = "737a5957f387b17e74d4ad2f440eb330b39a62c5"
@@ -535,9 +531,9 @@ uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
 
 [[OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "ab05aa4cc89736e95915b01e7279e61b1bfe33b8"
+git-tree-sha1 = "9a36165cf84cff35851809a40a928e1103702013"
 uuid = "458c3c95-2e84-50aa-8efc-19380b2a3a95"
-version = "1.1.14+0"
+version = "1.1.16+0"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -564,9 +560,9 @@ version = "8.44.0+0"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "1285416549ccfcdf0c50d4997a94331e88d68413"
+git-tree-sha1 = "0044b23da09b5608b4ecacb4e5e6c6332f833a7e"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "2.3.1"
+version = "2.3.2"
 
 [[Pixman_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -586,21 +582,21 @@ version = "3.0.0"
 
 [[PlotUtils]]
 deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
-git-tree-sha1 = "bb16469fd5224100e422f0b027d26c5a25de1200"
+git-tree-sha1 = "9888e59493658e476d3073f1ce24348bdc086660"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.2.0"
+version = "1.3.0"
 
 [[Plots]]
 deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs", "UnicodeFun", "Unzip"]
-git-tree-sha1 = "d457f881ea56bbfa18222642de51e0abf67b9027"
+git-tree-sha1 = "93e82cebd5b25eb33068570e3f63a86be16955be"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.29.0"
+version = "1.31.1"
 
 [[Polynomials]]
 deps = ["LinearAlgebra", "MutableArithmetics", "RecipesBase"]
-git-tree-sha1 = "0107e2f7f90cc7f756fee8a304987c574bbd7583"
+git-tree-sha1 = "a8d37fbaba422166e9f5354b6d8f6197e1f74fe5"
 uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
-version = "3.0.0"
+version = "3.1.3"
 
 [[Preferences]]
 deps = ["TOML"]
@@ -670,7 +666,7 @@ uuid = "6c6a2e73-6563-6170-7368-637461726353"
 version = "1.1.0"
 
 [[Seis]]
-deps = ["DSP", "Dates", "Geodesics", "Glob", "LibMseed", "LinearAlgebra", "RecipesBase", "StaticArrays", "Statistics"]
+deps = ["DSP", "Dates", "FFTW", "Geodesics", "Glob", "LibMseed", "LinearAlgebra", "RecipesBase", "StaticArrays", "Statistics"]
 path = ".."
 uuid = "dd80f4d8-c2f6-58bd-9bd3-4635f134261d"
 version = "0.3.10"
@@ -685,10 +681,6 @@ version = "0.2.4"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
-
-[[SharedArrays]]
-deps = ["Distributed", "Mmap", "Random", "Serialization"]
-uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [[Showoff]]
 deps = ["Dates", "Grisu"]
@@ -711,15 +703,20 @@ uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
 deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
-git-tree-sha1 = "5ba658aeecaaf96923dce0da9e703bd1fe7666f9"
+git-tree-sha1 = "a9e798cae4867e3a41cae2dd9eb60c047f1212db"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "2.1.4"
+version = "2.1.6"
 
 [[StaticArrays]]
-deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "cd56bf18ed715e8b09f06ef8c6b781e6cdc49911"
+deps = ["LinearAlgebra", "Random", "StaticArraysCore", "Statistics"]
+git-tree-sha1 = "9f8a5dc5944dc7fbbe6eb4180660935653b0a9d9"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.4.4"
+version = "1.5.0"
+
+[[StaticArraysCore]]
+git-tree-sha1 = "66fe9eb253f910fe8cf161953880cfdaef01cdf0"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.0.1"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -727,21 +724,21 @@ uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [[StatsAPI]]
 deps = ["LinearAlgebra"]
-git-tree-sha1 = "c82aaa13b44ea00134f8c9c89819477bd3986ecd"
+git-tree-sha1 = "2c11d7290036fe7aac9038ff312d3b3a2a5bf89e"
 uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
-version = "1.3.0"
+version = "1.4.0"
 
 [[StatsBase]]
 deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "8977b17906b0a1cc74ab2e3a05faa16cf08a8291"
+git-tree-sha1 = "48598584bacbebf7d30e20880438ed1d24b7c7d6"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.16"
+version = "0.33.18"
 
 [[StructArrays]]
 deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
-git-tree-sha1 = "e75d82493681dfd884a357952bbd7ab0608e1dc3"
+git-tree-sha1 = "ec47fb6069c57f1cee2f67541bf8f23415146de7"
 uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
-version = "0.6.7"
+version = "0.6.11"
 
 [[TOML]]
 deps = ["Dates"]
@@ -823,9 +820,9 @@ version = "1.25.0+0"
 
 [[XML2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
-git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+git-tree-sha1 = "58443b63fb7e465a8a7210828c91c08b92132dff"
 uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
-version = "2.9.12+0"
+version = "2.9.14+0"
 
 [[XSLT_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Libiconv_jll", "Pkg", "XML2_jll", "Zlib_jll"]

--- a/docs/src/function-index.md
+++ b/docs/src/function-index.md
@@ -9,6 +9,8 @@ AbstractTrace
 CartTrace
 Event
 CartEvent
+FourierTrace
+AbstractFourierTrace
 Station
 CartStation
 ```
@@ -20,11 +22,13 @@ channel_code
 dates
 enddate
 endtime
+frequencies
 is_east
 is_north
 is_horizontal
 is_vertical
 nearest_sample
+nfrequencies
 nsamples
 picks
 startdate
@@ -62,8 +66,10 @@ differentiate!
 differentiate
 envelope!
 envelope
+fft(::Trace)
 flip!
 flip
+ifft(::FourierTrace)
 integrate!
 integrate
 normalise!

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -19,10 +19,11 @@ for details.
 
 ## Types
 Working with Seis requires understanding a little bit about the types
-it uses.  Fundamentally, there are three important types:
+it uses.  Fundamentally, there are four important types:
 - [`Trace`](@ref)s, which contain
 - [`Station`](@ref)s and
-- [`Event`](@ref)s.
+- [`Event`](@ref)s; and also
+- [`FourierTrace`](@ref)s, which a frequency-domain `Trace`s.
 
 Each of these types have fields which either must contain data,
 or allow data to be [`missing`](https://docs.julialang.org/en/v1/manual/missing/#missing-1).
@@ -150,6 +151,36 @@ time of a section of data with no energy source implied.
   - `mag` holds an event magnitude;
   - `quakeml` holds information about an event in QuakeML form, if any;
   - `catalog` gives the name of the catalogue for this event.
+
+### `FourierTrace`s
+
+A `FourierTrace` is a frequency-domain version of its corresponding `Trace`.
+Usually you convert an existing `Trace` to the time domain by calling
+[`fft`](@ref fft(::Trace)), and then call [`ifft`](@ref ifft(::FourierTrace))
+to convert it back.  Because `Trace`s have to have real-valued data, a
+`FourierTrace`'s data is a one-sided Fourier transform.  You access the underlying
+data in the same way as for `Traces`, with [`trace`](@ref).
+
+A `FourierTrace`'s public fields are:
+
+- `delta`, giving the frequency spacing of the data;
+- `evt`, giving the event associated with the recording;
+- `sta`, giving station information; and
+- `meta` holding other things.
+
+`evt`, `sta` and `meta` are brought across from a `FourierTrace`'s
+originating `Trace` when constructed in the usual way with `fft`,
+and they are passed back to the new trace when calling `ifft`.
+
+`FourierTrace`s have the following accessor methods of their own:
+
+- [`frequencies`](@ref) gives the frequencies of each data point;
+- [`nfrequencies`](@ref) gives the number of data points; and
+- [`nsamples`](@ref) gives the number of data points in the equivalent
+  time-domain `Trace`.
+
+Because a `FourierTrace` retains enough information about the starting
+trace to turn it back, you can also call [`starttime`](@ref) on a `FourierTrace`.
 
 
 ## Getting data in

--- a/src/Plot.jl
+++ b/src/Plot.jl
@@ -77,9 +77,6 @@ function plot end
         max_samples=MAX_SAMPLES,
         show_picks=true,
         sort=nothing,
-        # TODO: Remove this when minor version bumped or a major version released.
-        # Deprecated
-        pick=nothing,
     )
 
     # Make single trace into a vector
@@ -183,7 +180,6 @@ function plot end
     end
 
     # Picks
-    show_picks = _deprecated_pick(pick, show_picks)
     if show_picks
         pick_times, pick_names = _picks_in_window(t, xlims[1], xlims[end])
         # Pick lines
@@ -277,9 +273,6 @@ section
         fill_down=nothing, fill_up=nothing,
         max_samples=MAX_SAMPLES,
         show_picks=false, zoom=1.0, absscale=nothing,
-        # TODO: Remove this when minor version bumped or a major version released.
-        # Deprecated
-        pick=nothing
     )
     # Arguments
     t = sec.args[1]
@@ -370,7 +363,6 @@ section
 
     # Picks
     ptime, py, names = Float64[], Float64[], String[]
-    show_picks = _deprecated_pick(pick, show_picks)
     if show_picks
         for (i, tt) in enumerate(t)
             for (key, (time, name)) in tt.picks
@@ -649,27 +641,6 @@ function _intercept(x1, y1, x2, y2, level)
     dy = y2 - y1
     ∇ = dy/dx
     x1 + (level - y1)/∇
-end
-
-# TODO: Remove this when minor version bumped or a major version released.
-"""
-    _deprecated_pick(pick, show_picks) -> showpicks′
-
-Obtain the value of the `picks` keyword argument, warning the user if
-`pick` is not `nothing` the first time this is called.  If `pick` is
-not unset, then return that value; otherwise use the input `picks`
-"""
-function _deprecated_pick(pick, show_picks)
-    if pick != nothing
-        if !HAVE_CALLED_PICK[]
-            @warn("The `pick` option to `plot` and `section` has been deprecated " *
-                  "in favour of `show_picks`, and will be removed in a future version.")
-            HAVE_CALLED_PICK[] = true
-        end
-        return pick
-    else
-        return show_picks
-    end
 end
 
 """

--- a/src/Seis.jl
+++ b/src/Seis.jl
@@ -27,11 +27,13 @@ module Seis
 
 export
     # Types
+    AbstractFourierTrace,
     AbstractTrace,
     CartEvent,
     CartStation,
     CartTrace,
     Event,
+    FourierTrace,
     GeogEvent,
     GeogStation,
     Station,
@@ -41,11 +43,13 @@ export
     dates,
     enddate,
     endtime,
+    frequencies,
     is_east,
     is_north,
     is_horizontal,
     is_vertical,
     nearest_sample,
+    nfrequencies,
     nsamples,
     picks,
     startdate,
@@ -74,8 +78,10 @@ export
     differentiate,
     envelope!,
     envelope,
+    fft,
     flip!,
     flip,
+    ifft,
     integrate!,
     integrate,
     normalise!,
@@ -131,6 +137,8 @@ using Statistics: mean, covm, varm
 import Glob
 import DSP
 import DSP.resample
+import FFTW
+import FFTW: fft, ifft
 import StaticArrays
 
 import Geodesics
@@ -139,6 +147,7 @@ include("compat.jl")
 
 # All basic types
 include("types.jl")
+include("spec.jl")
 include("conversion.jl")
 
 # File formats submodules

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -26,5 +26,12 @@ for Geom in (Cartesian, Geographic)
                 ) where {Tin,Vin,Tout,Vout}
             Trace{Tout,Vout,$geom{Tout}}($([:(getfield(t, $i)) for i in 1:fieldcount(Trace)]...))
         end
+
+        Base.convert(::Type{FourierTrace{T,V,$geom{T}}}, f::FourierTrace{T,V,$geom{T}}) where {T,V} = f
+        function Base.convert(::Type{FourierTrace{Tout,Vout,$geom{Tout}}},
+                f::FourierTrace{Tin,Vin,$geom{Tin}}
+                ) where {Tin,Tout,Vin,Vout}
+            FourierTrace{Tout,Vout,$geom{Tout}}($([:(getfield(f, $i)) for i in 1:fieldcount(FourierTrace)]...))
+        end
     end
 end

--- a/src/input_output.jl
+++ b/src/input_output.jl
@@ -345,7 +345,7 @@ miniSEED files can contain data in (amongst others) in `Float32`, `Float64`
 and `Int32` format.  This function will use whatever precision or type the
 data in `t` have and attempt to write.  If for example you want to write
 a trace with a `Float64` element type to a miniSEED file with element
-type `Float32`, you should first convert the trace using [`convert`](@ref).
+type `Float32`, you should first convert the trace using `convert`.
 (Note that since Seis does not support integer-valued trace data, it will
 not write 32-bit integer miniSEED files.)
 

--- a/src/spec.jl
+++ b/src/spec.jl
@@ -1,0 +1,405 @@
+# Types and methods for Fourier-domain traces
+
+"""
+    AbstractFourierTrace <: AbstractRecording
+
+Abstract type from which you should subtype if creating new types of
+frequency-domain traces.  Note that this is a subtype of `AbstractData`,
+meaning methods which work for `AbstractData` objects should work for
+`AbstractFourierTrace` objects too.
+
+# Interface
+
+!!! note
+    The formal interface for `AbstractFourierTrace`s is still a work in progress
+    and may change in a minor version increment.
+
+The following methods should be defined for all `AbstractFourierTrace`s `f`:
+
+- `trace(f)`: Return the data for the Fourier trace.
+- `frequencies(f)`: Return the frequency at each point of the Fourier series.
+- `times(f)`: Return the time at each sample of the time domain trace
+  corresponding to `f`.
+- `starttime(f)`: The time of the first sample of the corresponding time
+  domain trace.
+- `nsamples(f)`: The number of samples in the time domain trace corresponding to `f`.
+- `nfrequencies(f)`: The number of frequencies in the Fourier trace `f`.
+- `Base.eltype(f)`: The element type of the frequency domain data samples.
+"""
+abstract type AbstractFourierTrace <: AbstractData end
+
+"""
+    FourierTrace <: AbstractFourierTrace
+
+The Fourier transform of a [`Trace`](@ref).
+
+`FourierTrace`s contain all the information contained in their corresponding
+`Trace`, but with the addition of information on the original number of
+samples in the time domain trace, and an element type which much be `Complex`.
+Therefore, the fields `b`, `delta`, `evt`, `sta`, `picks`, and `meta` are all
+part of the public API and can be accessed the same way as for `Trace`s.
+
+The usual way to create `FourierTrace`s is by calling [`fft`](@ref) on a `Trace`.
+To convert back to a `Trace`, call [`ifft`](@ref).
+
+!!! note
+    `FourierTrace`s share many fields with the `Trace` they came from, including
+    the station and event, plus picks and metadata.  These fields are **not**
+    copied across, and are instead references to the same `Station`, `Event`,
+    and so on.  Therefore, any changes to the `FourierTrace` will be reflected
+    in the corresponding `Trace`.  To avoid this, do `f = fft(deepcopy(t))`.
+
+---
+    FourierTrace{T,V,P}(b, delta, nsamples, data, evt, sta, picks, meta)
+
+Create a new `FourierTrace` which corresponds to a `Trace` with start time
+`b` s, sampling interval `delta` s and `nsamples` data points.  `data`
+contains a set of Fourier coefficients, starting at 0 frequency up to
+the Nyquist frequency.  (The coefficient normalisation is defined to be
+the same as that used by FFTW.)  `evt`, `sta`, `picks` and `meta` should
+be taken from the original `Trace`.
+
+!!! note
+    One usually creates `FourierTrace`s by calling `fft` on a `Trace`.
+    Users are advised to use the keyword constructor (below) if
+    creating new `FourierTrace`s from scratch.
+
+---
+    FourierTrace(; b, delta, data, nsamples=(2*length(data) - 1), evt=Event(), sta=Station(), picks=nothing, meta=nothing)
+
+Create a `FourierTrace` directly from a set of Fourier coefficients.
+Users will usually construct a `FourierTrace` by calling [`fft`](@ref)
+on a `Trace` instead of using this constructor.
+
+# Keyword arguments
+- `b`: The starting time in s of the original recording this frequency
+  domain trace represents.
+- `delta`: The original sampling interval in s of the equivalent time
+  domain trace.
+- `data`: An `AbstractArray{<:Complex}` containing the set of Fourier
+  coefficients for this frequency domain trace.  Note that this is a
+  'one-sided' set, where the first index corresponds to 0 Hz and the final
+  index is the Nyquist frequency.  This is because `Trace`s represent real
+  quantities.
+- `nsamples`: The number of time domain samples in the origin time
+  domain trace which this frequency domain trace represents.  This allows
+  the `FourierTrace` to be converted back to the original `Trace` with no
+  loss of the number of points.
+- `evt`: An `Event` which defines the source and origin time for the data.
+  Normally this should be taken from the `Trace` being used to construct
+  the `FourierTrace`.
+- `sta`: A `Station` which defines the recording station for the data.
+  Normally this should be taken from the `Trace` being used to construct
+  the `FourierTrace`.
+
+---
+See also: [`Trace`](@ref), [`fft`](@ref), [`ifft`](@ref).
+"""
+mutable struct FourierTrace{T<:AbstractFloat,
+                            V<:AbstractVector{<:Complex{<:AbstractFloat}},
+                            P<:Position{T}
+                            } <: AbstractFourierTrace
+    b::T
+    # Frequency spacing in Hz, not  sampling interval in s
+    delta::T
+    nsamples::Int64
+    data::V
+    evt::Event{T,P}
+    sta::Station{T,P}
+    picks::SeisDict{Union{Symbol,Int},Pick{T}}
+    meta::SeisDict{Symbol,Any}
+
+    function FourierTrace{T,V,P}(b, delta, nsamples, data, evt, sta, picks, meta
+            ) where {T,V,P}
+        delta > 0 || throw(ArgumentError("delta cannot <= 0"))
+        nsamples >= 0 || throw(ArgumentError("nsamples cannot be negative"))
+        new{T,V,P}(b, delta, nsamples, data, evt, sta, picks, meta)
+    end
+end
+
+"""
+    FourierTrace(; b, delta, data, nsamples=(2*length(data) - 1), evt=Event(), sta=Station(), picks=nothing, meta=nothing)
+
+Create a `FourierTrace` directly from a set of Fourier coefficients.
+Users will usually construct a `FourierTrace` by calling [`fft`](@ref)
+on a `Trace` instead of using this constructor.
+
+# Keyword arguments
+- `b`: The starting time in s of the original recording this frequency
+  domain trace represents.
+- `delta`: The original sampling interval in s of the equivalent time
+  domain trace.
+- `data`: An `AbstractArray{<:Complex}` containing the set of Fourier
+  coefficients for this frequency domain trace.  Note that this is a
+  'one-sided' set, where the first index corresponds to 0 Hz and the final
+  index is the Nyquist frequency.  This is because `Trace`s represent real
+  quantities.
+- `nsamples`: The number of time domain samples in the origin time
+  domain trace which this frequency domain trace represents.  This allows
+  the `FourierTrace` to be converted back to the original `Trace` with no
+  loss of the number of points.
+- `evt`: An `Event` which defines the source and origin time for the data.
+  Normally this should be taken from the `Trace` being used to construct
+  the `FourierTrace`.
+- `sta`: A `Station` which defines the recording station for the data.
+  Normally this should be taken from the `Trace` being used to construct
+  the `FourierTrace`.
+"""
+function FourierTrace{T,V,P}(;
+        b, delta, data, nsamples=(2*length(data) - 1),
+        evt=Event{T,P}(), sta=Station{T,P}(),
+        picks=SeisDict{Union{Symbol,Int},Pick{T}}(),
+        meta=SeisDict{Symbol,Any}()
+    ) where {T,V,P}
+    FourierTrace{T,V,P}(b, delta, nsamples, data, evt, sta, picks, meta)
+end
+
+FourierTrace{T,V}(; kwargs...) where {T,V} = FourierTrace{T,V,Geographic{T}}(; kwargs...)
+FourierTrace{T}(; kwargs...) where {T} =
+    FourierTrace{T,Vector{Complex{T}},Geographic{T}}(; kwargs...)
+FourierTrace(; kwargs...) =
+    FourierTrace{Float64,Vector{Complex{Float64}},Geographic{Float64}}(; kwargs...)
+
+Base.eltype(f::AbstractFourierTrace) = eltype(trace(f))
+
+
+@eval begin
+    function Base.hash(f::FourierTrace, h::UInt)
+        $([:(h = hash(f.$f, h)) for f in fieldnames(FourierTrace)]...)
+        h
+    end
+
+    function Base.:(==)(a::FourierTrace, b::FourierTrace)
+        all(isequal(getfield(a, f), getfield(b, f)) for f in $(fieldnames(FourierTrace)))
+    end
+end
+
+# Get an array of values from an array of Fourier traces
+function Base.getproperty(t::AbstractArray{<:AbstractFourierTrace}, f::Symbol)
+    if f === :b || f === :delta || f === :nsamples || f === :data ||
+            f === :evt || f === :sta || f === :picks || f === :meta
+        getfield.(t, f)
+    else
+        getfield(t, f)
+    end
+end
+
+# Set an array of traces with a single value
+function Base.setproperty!(t::AbstractArray{<:AbstractFourierTrace}, f::Symbol, val)
+    if f === :b || f === :delta || f === :meta || f === :evt || f == :sta || f === :picks
+        for tt in t
+            setproperty!(tt, f, val)
+        end
+    else
+        # Fallback in case of desired dot-access to fields of an array type
+        setfield!(t, f, val)
+    end
+end
+
+# Set an array of traces with an array of values
+function Base.setproperty!(t::AbstractArray{<:AbstractFourierTrace}, f::Symbol, val::AbstractArray)
+    length(t) == length(val) || throw(DimensionMismatch())
+    for (tt, vv) in zip(t, val)
+        setproperty!(tt, f, vv)
+    end
+end
+
+Base.broadcastable(f::FourierTrace) = Ref(f)
+
+"""
+    fft(t::Trace) -> f::FourierTrace
+
+Convert the trace `t` into its equivalent frequency domain trace `f` by
+performing a Fourier transform.  The object returned is a [`FourierTrace`](@ref).
+
+# Example
+```
+julia> t = Trace(0, 0.01, 1000); trace(t) .= sin.(2π.*times(t)); # Sine wave of frequency 1 Hz
+
+julia> f = fft(t);
+
+julia> indmax = argmax(abs.(trace(f))); # Get index of maximum power
+
+julia> frequencies(f)[indmax] # Maximum frequency in Hz is 1 as expected
+1.0
+```
+
+See also: [`ifft`](@ref).
+"""
+function fft(t::Trace{T,<:AbstractVector{TV},P}) where {T,TV,P}
+    data = FFTW.rfft(trace(t))
+    delta = 1/(nsamples(t)*t.delta)
+    FourierTrace{T,Vector{Complex{TV}},P}(starttime(t), delta, nsamples(t),
+        data, t.evt, t.sta, t.picks, t.meta)
+end
+
+"""
+    ifft(t::FourierTrace[, d=2*nfrequencies(f) - 2]) -> t::Trace
+
+Convert the frequency domain [`FourierTrace`](@ref) `f` back into its
+equivalent time domain [`Trace`](@ref) `t`.
+
+Because `FourierTrace`s are usually constructed by calling [`fft`](@ref)
+on a `Trace`, the original number of time samples is kept in `f` and
+`t` therefore contains the same number of samples as before so long as
+the raw data in `f` has not been shortened or lengthened.  If it has,
+then it is assumed that `t` should have an even number of points.  If
+instead `t` should have an odd number of point, pass `d=npts`, where `npts`
+is the number of points needed.  `d` must be either one or two less than
+double the number of frequency points in `t`.
+
+# Example
+
+Showing that taking the inverse Fourier transform of the Fourier domain trace
+`f` gets us back to `t`:
+```
+julia> t = sample_data();
+
+julia> f = fft(t);
+
+julia> t′ = ifft(f);
+
+julia> isapprox(trace(t), trace(t′))
+true
+```
+
+A crude method to upsample a trace:
+```
+julia> t = Trace(0, 1, [0, 1, 0, -1, 0]);
+
+julia> f = fft(t);
+
+julia> append!(trace(f), zeros(nfrequencies(f)));
+
+julia> trace(ifft(f))
+10-element Vector{Float64}:
+  0.0
+  0.447213595499958
+  1.0
+  0.894427190999916
+ -1.7763568394002506e-16
+ -0.894427190999916
+ -1.0
+ -0.44721359549995787
+  1.7763568394002506e-16
+  0.0
+```
+
+See also: [`fft`](@ref).
+"""
+function ifft(f::FourierTrace{T,<:AbstractVector{<:Complex{TV}},P},
+        d::Union{Integer,Nothing}=nothing) where {T,TV,P}
+    # Use original number of points if the length of the frequency coefficients
+    # array has not been changed
+    n = if f.nsamples in 2*nfrequencies(f) .- (1, 2)
+        f.nsamples
+    # Otherwise, we can't know how long the time-domain trace is meant
+    # to be and so assume we want an even number of points unless we are told
+    # how many we should have
+    elseif d === nothing
+        2*nfrequencies(f) - 2
+    else
+        if d == 2*nfrequencies(f) - 1 || d == 2*nfrequencies(f) - 2
+            d
+        else
+            throw(ArgumentError("d must be either 2nf - 2 or 2nf - 1, " *
+                "where nf is the number of frequency points"))
+        end
+    end
+
+    # Scale the amplitude appropriately in case we have changed the
+    # spectrum length
+    scale = n/f.nsamples
+    # Ensure we pass `d` as an `Int` (not `Int64`) on x86, otherwise there
+    # is no method to construct a `FFTW.FakeArray`.
+    data = FFTW.irfft(trace(f), Int(n)).*scale
+
+    delta = 1/(2*(nfrequencies(f) - 1)*f.delta)
+    Trace{T,Vector{TV},P}(f.b, delta, data, f.evt, f.sta, f.picks, f.meta)
+end
+
+"""
+    nsamples(f::AbstraceFourierTrace[; even::Bool])
+
+For a `FourierTrace` `f`, return the number of samples in the equivalent
+time domain trace.
+
+The Fourier trace `f` records the number of points in the original trace
+used to create it with a call to [`fft`](@ref), however if the length of
+the trace has been changed, the number of samples of the time-domain
+equivalent of `f` may be odd or even.  In this case, pass either `even=true`
+to return the even number of sample, or `even=false` for the odd.
+
+# Example
+```
+julia> t = sample_data(); nsamples(t)
+1000
+
+julia> f = fft(t);
+
+julia> nsamples(f)
+1000
+```
+
+See also: [`nfrequencies`](@ref)
+"""
+function nsamples(f::AbstractFourierTrace; even::Union{Nothing,Bool}=nothing)
+    nfreq = nfrequencies(f)
+    if f.nsamples in (2nfreq - 1, 2nfreq - 2)
+        if even === nothing
+            return f.nsamples
+        else
+            return even ? 2nfreq - 2 : 2nfreq - 1
+        end
+    else
+        return (even === nothing || even) ? 2nfreq - 2 : 2nfreq - 1
+    end
+end
+
+"""
+    frequencies(f)
+
+Return the frequency in Hz of each data point in the frequency domain
+trace `f`.
+
+# Example
+```
+julia> f = fft(sample_data());
+
+julia> frequencies(f)
+0.0f0:0.1f0:50.0f0
+```
+"""
+frequencies(f::AbstractFourierTrace) = f.delta.*(0:(nfrequencies(f) - 1))
+
+"""
+    nfrequencies(f)
+
+Return the number of frequency points in the frequency domain trace `f`.
+
+# Example
+```
+julia> f = fft(sample_data());
+
+julia> nfrequencies(f)
+501
+```
+
+See also: [`nsamples`](@ref)
+"""
+nfrequencies(f) = length(trace(f))
+
+"""
+    trace(f::FourierTrace)
+
+Return the data for a [`FourierTrace`](@ref) object.
+"""
+trace(f::AbstractFourierTrace) = f.data
+
+"""
+    starttime(f::FourierTrace)
+
+Return the time of the first sample of the equivalent time-domain recording
+which would be obtained by [`ifft`](@ref ifft(::FourierTrace))
+"""
+starttime(f::AbstractFourierTrace) = f.b

--- a/src/types.jl
+++ b/src/types.jl
@@ -563,9 +563,23 @@ function Base.getproperty(p::AbstractArray{<:Pick}, field::Symbol)
 end
 
 """
-    AbstractTrace
+    AbstractData
+
+Abstract supertype of all single-channel datatypes in Seis.jl.  An
+`AbstractData` represents some data acquired at a point where it
+makes sense to associate that recording with a channel, and where the
+recording is limited to some period of time.  However, the recording
+may be in the time or frequency domain, and need not be stationary or
+evenly-sampled.
+"""
+abstract type AbstractData end
+
+"""
+    AbstractTrace <: AbstractData
 
 Abstract type from which you should subtype if creating new types of traces.
+`AbstractTrace`s are time-domain recordings (or synthetics) at a single
+channel.
 
 # Interface
 
@@ -573,13 +587,16 @@ Abstract type from which you should subtype if creating new types of traces.
     The formal interface for `AbstractTrace`s is still a work in progress and may change with
     a minor version increment.
 
-The following methods should be defined for all `AbstractTrace`s:
+The following methods should be defined for all `AbstractTrace`s `t`:
 
 - `trace(t)`: Return the data for the trace.
 - `times(t)`: Return the time at each sample of `t`.
 - `starttime(t)`: The time of the first sample.
 - `nsamples(t)`: The number of samples in `t`.
 - `Base.eltype(t)`: The element type of the data samples.
+- `t.evt`: Return the `Event` associated with this trace.
+- `t.sta`: Return the `Station` at which this trace was recorded.
+- `t.meta`: Return a `SeisDict{Symbol,Any}` into which metadata may be placed.
 """
 abstract type AbstractTrace end
 
@@ -724,7 +741,7 @@ for T in (Cartesian, Geographic, Event, Station, Trace)
 end
 
 # Treat single objects as scalars in broadcasting
-Base.broadcastable(t::Union{AbstractTrace,Event,Station,Position,Pick}) = Ref(t)
+Base.broadcastable(t::Union{Trace,Event,Station,Position,Pick}) = Ref(t)
 
 # Element type of trace
 Base.eltype(::Trace{T,V,P}) where {T,V,P} = eltype(V)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,6 +14,7 @@ using .TestHelpers
     include("synth.jl")
     include("traveltimes.jl")
     include("types.jl")
+    include("spec.jl")
     include("util.jl")
 
     @testset "IO" begin

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -1,0 +1,38 @@
+# Fourier traces
+
+using Seis
+using Test
+
+@testset "FourierTrace" begin
+    @testset "fft/ifft" begin
+        t = sample_data()
+        f = fft(t)
+        t′ = ifft(f)
+
+        @testset "Field references" begin
+            @testset "Trace to FourierTrace" begin
+                @test t.b == f.b
+                @test t.evt === f.evt
+                @test t.sta === f.sta
+                @test t.meta === f.meta
+            end
+
+            @testset "Trace to ifft(FourierTrace)" begin
+                @test t.evt === t′.evt
+                @test t.sta === t′.sta
+                @test t.meta === t′.meta
+            end
+        end
+
+        @testset "Round-trip" begin
+            for p in propertynames(t)
+                v, v′ = getfield.((t, t′), p)
+                if p == :t
+                    @test v ≈ v′
+                else
+                    @test isequal(v, v′)
+                end
+            end
+        end
+    end
+end

--- a/test/util.jl
+++ b/test/util.jl
@@ -305,7 +305,7 @@ using .TestHelpers
                 end
             end
         end
-    end
+   end
 
     @testset "Dates and times" begin
         # dates


### PR DESCRIPTION
- Plot: Remove deprecated picks keyword argument
- Add `FourierTrace` type
