### PR TITLE
WIP: Add spectrogram function

### DIFF
--- a/src/Seis.jl
+++ b/src/Seis.jl
@@ -127,7 +127,9 @@ export
     rotate_to_gcp,
     rotate_to_lqt!,
     rotate_to_lqt,
-    sort_traces_right_handed
+    sort_traces_right_handed,
+    # Analysis
+    spectrogram
 
 using Dates
 using LinearAlgebra
@@ -136,7 +138,7 @@ using Statistics: mean, covm, varm
 
 import Glob
 import DSP
-import DSP.resample
+import DSP: resample, spectrogram
 import FFTW
 import FFTW: fft, ifft
 import StaticArrays
@@ -165,6 +167,7 @@ include("operations.jl")
 include("rotation.jl")
 include("filtering.jl")
 include("sample_data.jl")
+include("spectrogram.jl")
 
 # Functionality submodules
 include("Synth.jl")

--- a/src/spectrogram.jl
+++ b/src/spectrogram.jl
@@ -1,0 +1,42 @@
+"""
+    spectrogram(trace; length=(endtime(t) - starttime(t))/20, overlap=0.5, window=nothing) -> spec
+
+Calculate the spectrogram for the data in `trace`.  Each segment is `length` s
+long, and overlaps with the next by a fraction of `overlap` (i.e., `overlap`
+must be 0 s or greater, and less than 1).  Note that these values are rounded
+to an integer number of samples in both cases.
+
+By default, no windowing of each segment (of `length` s) is performed;
+pass a windowing function or vector of amplitudes to `window` to window each
+segment before the periodogram is computed.  See [`DSP.periodogram`](@ref)
+for more details of the kind of windowing which is possible.
+
+# Examples
+```
+julia> t = sample_data();
+
+julia> spec = spectrogram(t);
+
+julia> spec.time
+52.90999984741211:0.25:62.40999984741211
+```
+"""
+function DSP.spectrogram(t::AbstractTrace;
+        length=max((endtime(t) - starttime(t))/20, 2t.delta), overlap=0.5, window=nothing,
+        pad=nothing)
+    length > 0 || throw(ArgumentError("`length` must be greater than 0 s"))
+    length >= t.delta || throw(ArgumentError(
+        "`length` must at least the sampling interval"))
+    0 <= overlap < 1 || throw(ArgumentError(
+        "`overlap` must be greater than or equal to 0, and less than 1"))
+    pad === nothing || 1 <= pad || throw(ArgumentError("`pad` must be 1 or greater"))
+    delta = t.delta
+    n = round(Int, length/delta)
+    noverlap = floor(Int, overlap*n)
+    nfft = (pad === nothing || pad == 1) ? DSP.nextfastfft(n) : round(Int, pad*n)
+    # Compute spectrogram
+    spec = DSP.spectrogram(trace(t), n, noverlap;
+        fs=1/delta, window=window, nfft=nfft)
+    # Update times in spectrogram to reflect sample times of trace
+    typeof(spec)(spec.power, spec.freq, spec.time .+ starttime(t))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,6 +16,7 @@ using .TestHelpers
     include("types.jl")
     include("spec.jl")
     include("util.jl")
+    include("spectrogram.jl")
 
     @testset "IO" begin
         include("io/sac.jl")

--- a/test/spectrogram.jl
+++ b/test/spectrogram.jl
@@ -1,0 +1,47 @@
+# Periodograms and spectrograms
+using Test
+using Seis
+
+using DSP: DSP
+
+@testset "Periodograms and spectrograms" begin
+    @testset "spectrogram" begin
+        @testset "ArgumentErrors" begin
+            let t = sample_data()
+                @test_throws ArgumentError spectrogram(t, length=-1)
+                @test_throws ArgumentError spectrogram(t, overlap=-1)
+                @test_throws ArgumentError spectrogram(t, overlap=1)
+                @test_throws ArgumentError spectrogram(t, pad=0.5)
+                @test_throws ArgumentError spectrogram(t, length=0.00001)
+            end
+        end
+
+        @testset "Types" begin
+            spec = spectrogram(sample_data())
+            @test hasproperty(spec, :time)
+            @test hasproperty(spec, :freq)
+            @test hasproperty(spec, :power)
+        end
+
+        @testset "Array sizes" begin
+            t = Trace(0, 0.01, rand(1000))
+            len = 0.5
+            overlap = 0.75
+            spec = spectrogram(t, length=len, overlap=overlap, window=DSP.hamming)
+            @test extrema(spec.freq) == (0, 1/2t.delta)
+            @test first(spec.time) ≈ starttime(t) + len/2
+        end
+
+        @testset "Defaults" begin
+            let t = sample_data()
+                compare_specs(s1, s2) =
+                    all(getfield(s1, f) == getfield(s2, f)
+                        for f in (:time, :freq, :power))
+                @test compare_specs(spectrogram(t), spectrogram(t, overlap=0.5))
+                @test compare_specs(spectrogram(t),
+                    spectrogram(t, length=(endtime(t) - starttime(t))/20))
+                @test compare_specs(spectrogram(t), spectrogram(t, pad=1))
+            end
+        end
+    end
+end


### PR DESCRIPTION
Add `spectrogram`, which uses `DSP.spectrogram` to compute the
spectrogram for an `AbstractTrace`.  Replace `DSP`s literalist
positional and keyword arguments with ones based around times.

Add start of tests.
