### PR TITLE
rotate_through[!]: Correctly propagate angle tolerance

### DIFF
--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -18,6 +18,21 @@ channels are horizontals.
 The optional keyword argument `tol` specifies the angle in ° by which
 the traces must be orthogonal; see [`are_orthogonal`](@ref).
 
+# Example
+```
+julia> e, n = sample_data(:local)[1:2];
+
+julia> rotate_through!(n, e, 20); # Rotate 20° clockwise looking down
+
+julia> n.sta.azi, e.sta.azi
+(20.0f0, 110.0f0)
+
+julia> rotate_through!(e, n, 20); # Rotate in opposite direction
+
+julia> n.sta.azi, e.sta.azi
+(6.5939315f-7, 90.0f0)
+```
+
 See also: [`rotate_through`](@ref), [`rotate_to_gcp!`](@ref),
 [`rotate_to_azimuth_incidence!`](@ref)
 """

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -23,7 +23,7 @@ See also: [`rotate_through`](@ref), [`rotate_to_gcp!`](@ref),
 """
 function rotate_through!(t1::AbstractTrace, t2::AbstractTrace, phi; tol=_angle_tol(t1, t2))
     T = promote_type(eltype(t1), eltype(t2))
-    if !are_orthogonal(t1, t2)
+    if !are_orthogonal(t1, t2; tol=tol)
         throw(ArgumentError("traces must be orthogonal"))
     elseif nsamples(t1) != nsamples(t2)
         throw(ArgumentError("traces must be same length"))

--- a/src/rotation.jl
+++ b/src/rotation.jl
@@ -188,7 +188,7 @@ altered, and the returned traces point to the same data as the input traces, but
 possibly in a different order.  Use [`rotate_to_azimuth_incidence`](@ref) to return
 copies of the traces and leave the original traces unmodified.
 
-See also: [`rotate_to_azimuth_incidence!`](@ref), [`rotate_to_gcp!`](@ref),
+See also: [`rotate_to_azimuth_incidence`](@ref), [`rotate_to_gcp!`](@ref),
 [`rotate_to_lqt!`](@ref), [`rotate_through!`](@ref)
 """
 function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::AbstractTrace,
@@ -200,7 +200,7 @@ function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::
     # Check traces
     if any(x -> x.sta.azi === missing || x.sta.inc === missing, (t1, t2, t3))
         throw(ArgumentError("traces must contain station orientation information"))
-    elseif !are_orthogonal(t1, t2, t3)
+    elseif !are_orthogonal(t1, t2, t3; tol=tol)
         throw(ArgumentError("traces must be orthogonal"))
     elseif !(axes(trace(t1)) == axes(trace(t2)) == axes(trace(t3)))
         throw(ArgumentError("traces must all be the same length"))
@@ -210,7 +210,7 @@ function rotate_to_azimuth_incidence!(t1::AbstractTrace, t2::AbstractTrace, t3::
         throw(ArgumentError("traces must all have the same start time and sampling interval"))
     end
     # Sort traces so that we start with a right-handed set
-    x, y, z, perm = sort_traces_right_handed(t1, t2, t3)
+    x, y, z, perm = sort_traces_right_handed(t1, t2, t3; tol=tol)
 
     # Component directions
     uˣ, uʸ, uᶻ = _direction_vector.((x, y, z))

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -210,7 +210,12 @@ angles_are_same(a, b, tol=Seis._angle_tol(typeof(float(a)), typeof(float(b)))) =
             @testset "Orthogonal" begin
                 e′ = deepcopy(e)
                 e′.sta.azi += 5
-                @test_throws ArgumentError rotate_to_azimuth_incidence!(e′, n, z, 0, 0)
+                @testset "Default tolerance" begin
+                    @test_throws ArgumentError rotate_to_azimuth_incidence!(e′, n, z, 0, 0)
+                end
+                @testset "Custom tolerance" begin
+                    @test length(rotate_to_azimuth_incidence(e′, n, z, 0, 0, tol=90)) == 3
+                end
             end
 
             @testset "Trace data" begin

--- a/test/rotation.jl
+++ b/test/rotation.jl
@@ -16,7 +16,14 @@ angles_are_same(a, b, tol=Seis._angle_tol(typeof(float(a)), typeof(float(b)))) =
     @testset "rotate_through" begin
         @testset "Argument checking" begin
             @testset "Not orthogonal" begin
-                @test_throws ArgumentError rotate_through(sample_data(), sample_data(), 10)
+                @testset "Default tolerance" begin
+                    @test_throws ArgumentError rotate_through(sample_data(), sample_data(), 10)
+                end
+                @testset "Custom tolerance" begin
+                    e, n, z = sample_data(:local)[1:3]
+                    e.sta.azi += 1e-5
+                    @test_throws ArgumentError rotate_through(e, n, 10, tol=1e-6)
+                end
             end
             @testset "Different samples" begin
                 e, n = sample_data(:local)[1:2]


### PR DESCRIPTION
Before this commit, the angle comparison tolerance in the check
for trace orthogonality in `rotate_through!` was not propagated
through to the call to `are_orthogonal`, despite the documented
API.  This fixes the bug.

Edit: Along the way, I also discovered a couple more places where `tol` was not properly propagated, so these are also now fixed.

Closes #34.
