### PR TITLE
Update DSP to v0.8

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -16,7 +16,7 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
-DSP = "0.6, 0.7"
+DSP = "0.8"
 FFTW = "1"
 Glob = "1"
 LibMseed = "0.3.2"

--- a/src/filtering.jl
+++ b/src/filtering.jl
@@ -17,6 +17,10 @@ Apply a filter `f` to a `Seis.Trace` `t` in-place and return the modified
 original trace.
 """
 function DSP.filt!(f, t::AbstractTrace, args...)
+    # FIXME: This can be replaced with
+    #     trace(t) .= DSP.filt(f, trace(t), args...)
+    # because the RHS will be allocated before the LFS is filled in, and
+    # there is therefore no aliasing.
     trace′ = deepcopy(trace(t))
     trace(t) .= DSP.filt(f, trace′, args...)
     t
@@ -56,8 +60,8 @@ ripple power, etc., should be specified when providing the filter kind.
 """
 function bandpass!(t::AbstractTrace, f1, f2;
                    poles=2, twopass=false, kind=DSP.Butterworth(poles))
-    response = DSP.Bandpass(f1, f2, fs=1/t.delta)
-    _apply_filter!(t, response, kind, twopass)
+    filter = DSP.digitalfilter(DSP.Bandpass(f1, f2), kind; fs=1/t.delta)
+    _apply_filter!(t, filter, twopass)
 end
 bandpass(t, args...; kwargs...) = bandpass!(deepcopy(t), args...; kwargs...)
 @doc (@doc bandpass!) bandpass
@@ -82,8 +86,8 @@ ripple power, etc., should be specified when providing the filter kind.
 """
 function bandstop!(t::AbstractTrace, f1, f2;
                    poles=2, twopass=false, kind=DSP.Butterworth(poles))
-    response = DSP.Bandstop(f1, f2, fs=1/t.delta)
-    _apply_filter!(t, response, kind, twopass)
+    filter = DSP.digitalfilter(DSP.Bandstop(f1, f2), kind; fs=1/t.delta)
+    _apply_filter!(t, filter, twopass)
 end
 bandstop(t, args...; kwargs...) = bandstop!(deepcopy(t), args...; kwargs...)
 @doc (@doc bandstop!) bandstop
@@ -107,8 +111,8 @@ ripple power, etc., should be specified when providing the filter kind.
 """
 function highpass!(t::AbstractTrace, f;
                    poles=2, twopass=false, kind=DSP.Butterworth(poles))
-    response = DSP.Highpass(f, fs=1/t.delta)
-    _apply_filter!(t, response, kind, twopass)
+    filter = DSP.digitalfilter(DSP.Highpass(f), kind; fs=1/t.delta)
+    _apply_filter!(t, filter, twopass)
 end
 highpass(t, args...; kwargs...) = highpass!(deepcopy(t), args...; kwargs...)
 @doc (@doc highpass!) highpass
@@ -132,24 +136,22 @@ ripple power, etc., should be specified when providing the filter kind.
 """
 function lowpass!(t::AbstractTrace, f;
                   poles=2, twopass=false, kind=DSP.Butterworth(poles))
-    response = DSP.Lowpass(f, fs=1/t.delta)
-    _apply_filter!(t, response, kind, twopass)
+    filter = DSP.digitalfilter(DSP.Lowpass(f), kind; fs=1/t.delta)
+    _apply_filter!(t, filter, twopass)
 end
 lowpass(t, args...; kwargs...) = lowpass!(deepcopy(t), args...; kwargs...)
 @doc (@doc lowpass!) lowpass
 
 """
-    _apply_filter!(t::Trace, response, kind, twopass) -> t
+    _apply_filter!(t::Trace, filter, twopass) -> t
 
-Apply a filter of `kind` with `response` to the trace `t` and return the modified
-trace.
+Apply a filter `filter` to the trace `t` and return the modified trace.
 
-`response` will usually be one of `Highpass`, `Lowpass`, `Bandpass` or `Bandstop`.
+`filter` will usually be one of `Highpass`, `Lowpass`, `Bandpass` or `Bandstop`.
 
 `kind` will usually be one of `Butterworth`, `Chebyshev1, `Chebyshev2`
 or `Elliptic` from the `DSP.Filters` module.
 """
-function _apply_filter!(t::AbstractTrace, response, kind, twopass)
-    f = DSP.digitalfilter(response, kind)
-    twopass ? filtfilt!(f, t) : DSP.filt!(f, t)
+function _apply_filter!(t::AbstractTrace, filter, twopass)
+    twopass ? filtfilt!(filter, t) : DSP.filt!(filter, t)
 end


### PR DESCRIPTION
Do not merge until satisfied that dependents of Seis.jl or
packages often used with it that depend on DSP.jl are compatible
with v0.8.

v0.8 of DSP is a breaking change.  Update filtering to use the new
version and change compatibility to only be compatible with the
new version.
