### PR TITLE
Makie: Add plot_hodogram[!] for particle motion plots

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -66,8 +66,8 @@
 ### Plotting with [Makie.jl](https://docs.makie.org/stable)
 - If you are on Julia v1.9 or greater and have loaded
   the `Makie` package (e.g., via one of its backends like `using GLMakie`),
-  then the `plot_traces` and `plot_section` functions can be used to plot
-  multiple traces.
+  then the `plot_traces`, `plot_section` and `plot_hodogram` functions can
+  be used to plot traces in different ways.
   Users of earlier versions or those who have not loaded Makie are unaffected.
 
 ## Deprecated or removed

--- a/docs/src/plotting-makie.md
+++ b/docs/src/plotting-makie.md
@@ -40,6 +40,13 @@ The figures produced here were made using CairoMakie unless otherwise noted.
 
 ## Plotting functions
 
+### New figure or existing axis?
+The Makie plotting functions mostly come in two flavours—one which adds a plot
+into an existing axis (and ends with `!`, such as [`plot_section!`](@ref)),
+and another with a `!` which creates a returns a new `Makie.Figure`
+object, such as [`plot_section`](@ref).  We discuss the new-figure versions
+below.
+
 ### `Makie.plot`: Default plot
 Seis.jl extends `Makie.plot` to produce the default kind of plot for
 whatever Seis.jl types are passed to it.  At present, it will forward to
@@ -53,6 +60,9 @@ similar to simply plotting `trace(t)` against `times(t)`.
 However, `plot_traces` when applied to a single `Trace` or an
 `AbstractArray{<:Trace}` offers options to scale plots relatively,
 show pick times, and so on.
+
+(Note that there is no in-place version of `plot_traces` because it requires
+several axes.)
 
 #### Examples
 1: A simple plot for a single trace, showing the picks.
@@ -90,7 +100,7 @@ Seis.plot_traces
 ```
 
 
-### `section`: Record sections
+### `plot_section`: Record sections
 `section` plots a 'record section', or a set of traces where a trace's
 position on the y-axis is determined by some other information.
 
@@ -184,7 +194,38 @@ downsampling.
     If using `decimate=false` with very large datasets (many millions of
     points) plotting may become extremely slow or even unstable.
 
+#### Full docstrings
+```@docs
+Seis.plot_section!
+Seis.plot_section
+```
+
+### `plot_hodogram`: Particle motion plots
+Hododgrams, or particle motion plots, are parametric plots
+of two or three components of motion through time.  These can be plotted
+in Seis using `plot_hodogram`.
+
+#### Examples
+Hodogram of the horizontal components of an earthquake, windowed around
+the P-wave arrival, showing the backazimuth to the event location,
+and the particle motion and backazimuth lines set to have different
+colours.
+
+```@example plotting_makie
+t = e, n, z = sample_data(:regional)[1:3]
+cut!.(t, 50, 70)
+plot_hodogram(e, n; backazimuth=true, lines=(color=:blue,), backazimuth_lines=(color=:red, linestyle=:dash))
+```
+
+We can also create a 3D plot of the particle motion across all three
+components:
+
+```@example plotting_makie
+plot_hodogram(e, n, z)
+```
+
 #### Full docstring
 ```@docs
-Seis.plot_section
+Seis.plot_hodogram!
+Seis.plot_hodogram
 ```

--- a/ext/SeisMakieExt.jl
+++ b/ext/SeisMakieExt.jl
@@ -567,6 +567,198 @@ function _calculate_y_shifts(ts, y_values)
 end
 
 """
+    Seis.plot_hodogram!([ax::Makie.Axis,] t1, t2; kwargs...) -> plot
+
+Plot the particle motion for two traces `t1` and `t2` into an existing
+axis `ax` (or the currently active axis if none is given).
+
+## Keyword arguments
+- `backazimuth=false`: If `true`, plot a line showing the direction of the
+  backazimuth from the first trace to the event if present in the trace
+  headers.
+- `backazimuth_lines=(color=:red,)`: Passed to the `Makie.lines` call
+  which plots the backazimuth line.
+- `lines=(color=:black,)`: Passed to the `Makie.lines` call which plots the traces.
+
+## Example
+```
+julia> fig = Makie.Figure()
+
+julia> ax = Makie.Axis(fig[1,1]; aspect=Makie.DataAspect())
+
+julia> plot_hodogram!(ax, sample_data(:local)[1:2]...)
+```
+
+See also: [`plot_hodogram`](@ref).
+"""
+function Seis.plot_hodogram!(
+    ax::Makie.Axis, t1::Seis.AbstractTrace, t2::Seis.AbstractTrace;
+    backazimuth=false,
+    lines=(color=:black,),
+    backazimuth_lines=(color=:red, linewidth=2),
+)
+    _check_hodogram_args(t1, t2)
+
+    maxval = _max_abs_value(t1, t2)
+
+    pl = Makie.lines!(ax, Seis.trace(t1), Seis.trace(t2); lines...)
+
+    if backazimuth
+        _plot_hodogram_backazimuth!(ax, t1, t2, maxval, backazimuth_lines)
+    end
+
+    pl
+end
+Seis.plot_hodogram!(t1::Seis.AbstractTrace, t2::Seis.AbstractTrace; kwargs...) = 
+    Seis.plot_hodogram!(Makie.current_axis(), t1, t2; kwargs...)
+
+"""
+    Seis.plot_hodogram!([ax::Union{Makie.Axis3,Makie.LScene},] t1, t2, t3; lines=(color=:black, linewidth=2))
+
+Plot a 3D hodogram of three traces into an existing 3D Makie axis, if given,
+or the current axis if not.  In this case the current axis must be one
+of the supported Makie axis types.
+
+# Example
+```
+julia> fig = Makie.Figure()
+
+julia> ax = Makie.Axis3(fig[1,1]; aspect=(1, 1, 1))
+
+julia> plot_hodogram!(ax, sample_data(:local)[1:3]...)
+```
+"""
+function Seis.plot_hodogram!(
+    ax::Union{Makie.Axis3,Makie.LScene},
+    t1::Seis.AbstractTrace,
+    t2::Seis.AbstractTrace,
+    t3::Seis.AbstractTrace;
+    lines=(color=:black,),
+)
+    _check_hodogram_args(t1, t2, t3)
+
+    Makie.lines!(ax, Seis.trace.((t1, t2, t3))...; lines...)
+end
+function Seis.plot_hodogram!(
+    t1::Seis.AbstractTrace, t2::Seis.AbstractTrace, t3::Seis.AbstractTrace;
+    kwargs...
+)
+    Seis.plot_hodogram!(Makie.current_axis(), t1, t2, t3; kwargs...)
+end
+
+"""
+    Seis.plot_hodogram(t1, t2; kwargs...) -> fig, ax, pl
+
+Create a new figure and fill it with a particle motion plot or
+'hodogram' of the two `Seis.AbstractTrace`s `t1` and `t2`.
+Most `kwargs` are passed onto [`plot_hodogram!`](@ref); see
+[`plot_hodogram!`](@ref) for more information.
+
+The following keyword arguments are unique to this function and are
+not passed on:
+
+- `figure`: Dictionary, named tuple or set of pairs containing
+  keyword arguments which are passed to `Makie.Figure`, controlling
+  the appearance of the figure.
+- `axis`: Dictionary, named tuple or set of pairs containing
+  keyword arguments which are passed to `Makie.Axis`, controlling
+  the appearance of the axis.
+
+# Example
+```
+julia> ts = cut!.(sample_data(:regional)[1:2], 0, 10);
+
+julia> plot_hodogram(ts[1], ts[2])
+```
+
+See also: [`plot_hodogram!`](@ref).
+"""
+function Seis.plot_hodogram(
+    t1::Seis.AbstractTrace, t2::Seis.AbstractTrace;
+    backazimuth=false,
+    figure=(size=(320, 300),),
+    axis=(aspect=Makie.DataAspect(), xgridvisible=false, ygridvisible=false),
+    lines=(color=:black,),
+    backazimuth_lines=(color=:red,),
+)
+    _check_hodogram_args(t1, t2)
+
+    maxval = _max_abs_value(t1, t2)
+    limits = 1.01*maxval.*(-1, 1, -1, 1)
+    xlabel = coalesce(t1.sta.cha, string(t1.sta.azi))
+    ylabel = coalesce(t2.sta.cha, string(t2.sta.azi))
+
+    fig = Makie.Figure(; figure...)
+    ax = Makie.Axis(fig[1,1];
+        xlabel,
+        ylabel,
+        limits,
+        axis...
+    )
+
+    pl = Makie.lines!(ax, Seis.trace(t1), Seis.trace(t2); lines...)
+
+    if backazimuth
+        _plot_hodogram_backazimuth!(ax, t1, t2, maxval, backazimuth_lines)
+    end
+
+    Makie.FigureAxisPlot(fig, ax, pl)
+end
+
+"""
+    Seis.plot_hodogram(t1, t2, t3; figure=(size=(500, 500),), axis_type=Makie.Axis3, axis=(), lines=(color=:black, linewidth=2)) -> fig, ax, pl
+
+Plot a 3D hodogram of three components.
+
+As well as the `figure` and `axis` keyword arguments which are passed on
+as above, this 3D version also supports the follow keyword arguments:
+
+- `axis_type`: Makie type of 3D axis.  Currently supported are:
+  - `Makie.Axis3`: A customisable 3D axis suitable for publication-quality
+    plots.
+  - `Makie.LScene`: A basic 3D axis which supports zooming, unlike `Axis3`.
+
+# Example
+```
+julia> ts = sample_data(:regional);
+
+julia> plot_hodogram(cut.(ts[1:3], 0, 30)...)
+"""
+function Seis.plot_hodogram(
+    t1::Seis.AbstractTrace,
+    t2::Seis.AbstractTrace,
+    t3::Seis.AbstractTrace;
+    figure=(size=(500, 500),),
+    axis_type=Makie.Axis3,
+    axis=(),
+    lines=(color=:black,),
+)
+    _check_hodogram_args(t1, t2)
+
+    maxval = _max_abs_value(t1, t2)
+    limits = 1.01*maxval.*(-1, 1, -1, 1, -1, 1)
+    xlabel = coalesce(t1.sta.cha, string(t1.sta.azi))
+    ylabel = coalesce(t2.sta.cha, string(t2.sta.azi))
+    zlabel = coalesce(t3.sta.cha, string(t3.sta.azi))
+
+    fig = Makie.Figure(; figure...)
+
+    axis_defaults = if axis_type == Makie.Axis3
+        (; xlabel, ylabel, limits, aspect=(1, 1, 1), viewmode=:fit)
+    elseif axis_type == Makie.LScene
+        ()
+    else
+        throw(ArgumentError("unsupported axis type $axis_type for three-component hodogram"))
+    end
+
+    ax = axis_type(fig[1,1]; axis_defaults..., axis...)
+
+    pl = Makie.lines!(ax, Seis.trace(t1), Seis.trace(t2), Seis.trace(t3); lines...)
+
+    Makie.FigureAxisPlot(fig, ax, pl)
+end
+
+"""
     _decimation_value(trace, shift, t1, t2, max_samples) -> n
 
 Return the decimation value `n` required to reduce the number
@@ -581,6 +773,33 @@ function _decimation_value(times, t1, t2, max_samples)
     npts = sum(x -> t1 <= x <= t2, times)
     max(1, round(Int, npts/max_samples))
 end
+
+function _check_hodogram_args(traces...)
+    t1, ts = Iterators.peel(traces)
+
+    if !all(t -> Seis.nsamples(t) == Seis.nsamples(t1), ts)
+        throw(ArgumentError("both traces must be the same length"))
+    elseif !all(t -> t.delta == t1.delta, ts)
+        throw(ArgumentError("both traces must have the same sampling interval"))
+    elseif !all(t -> Seis.starttime(t) == Seis.starttime(t1), ts)
+        throw(ArgumentError("both traces must have the same start time"))
+    end
+
+    nothing
+end
+
+"""
+Add the backazimuth to an existing plot, where `maxval` is the maximum absolute
+amplitude across both traces.
+"""
+function _plot_hodogram_backazimuth!(ax, t1, t2, maxval, backazimuth_lines)
+    β = Seis.backazimuth(t1) - t2.sta.azi
+    xβ, yβ = (√2*maxval) .* sincos(deg2rad(β))
+    Makie.lines!(ax, [0, xβ], [0, yβ]; backazimuth_lines...)
+end
+
+"Return the maximum absolute value over all traces"
+_max_abs_value(ts...) = maximum(t -> maximum(abs, Seis.trace(t)), ts)
 
 function _kwargs_deprecation(old_name, new_name, kwargs_old, kwargs_new)
     if !isnothing(kwargs_old)

--- a/src/Seis.jl
+++ b/src/Seis.jl
@@ -130,6 +130,8 @@ export
     rotate_to_lqt,
     sort_traces_right_handed,
     # Plotting
+    plot_hodogram!,
+    plot_hodogram,
     plot_section!,
     plot_section,
     plot_traces,

--- a/src/makie.jl
+++ b/src/makie.jl
@@ -1,6 +1,30 @@
 # Stubs for plotting with Makie when it is loaded
 
 """
+    plot_hodogram!
+
+Function to plot the particle motion of two (in 2D) or three (in 3D)
+traces.  This can be used once you have loaded a
+[Makie](https://docs.makie.org/stable) backed (e.g., via
+`using GLMakie`, `using CairoMakie`, etc.).
+
+See docstrings below after loading a Makie backend for more information.
+"""
+function plot_hodogram! end
+
+"""
+    plot_hodogram
+
+Function to plot the particle motion of two (in 2D) or three (in 3D)
+traces.  This can be used once you have loaded a
+[Makie](https://docs.makie.org/stable) backed (e.g., via
+`using GLMakie`, `using CairoMakie`, etc.).
+
+See docstrings below after loading a Makie backend for more information.
+"""
+function plot_hodogram end
+
+"""
     plot_traces
 
 Function to plot several traces which can be used once you have


### PR DESCRIPTION
Implement hodograms with the new `plot_hodogram` and `plot_hodogram!`
functions.  These take either two (for 2D) or three (3D) traces and
allow either a new `Makie.Figure` to be created and returned, or an
existing axis to be used.
