### PR TITLE
CI: Test on macOS ARM and fix test for miniSEED reading

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,9 @@ jobs:
           - os: ubuntu-latest
             version: '1'
             arch: x86
+          - os: macos-14
+            version: '1'
+            arch: arm64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2

--- a/test/io/miniseed.jl
+++ b/test/io/miniseed.jl
@@ -71,16 +71,22 @@ io_data_path(file) = joinpath(@__DIR__, "..", "test_data", "io", file)
                 @test startdate(t[2]) - enddate(t[1]) == Dates.Second(2)
             end
 
-            @testset "No gap allowed" begin
-                @test read_mseed(path, maximum_gap=0) == read_mseed(path)
-            end
+            # Neither ARM nor PowerPC are currently supported in using
+            # `LibMseed.read(...; time_tolerance)`:
+            if Sys.ARCH != :aarch64
+                @testset "No gap allowed" begin
+                    @test read_mseed(path, maximum_gap=0) == read_mseed(path)
+                end
 
-            @testset "Single segment from larger gap" begin
-                t = read_mseed(path, maximum_gap=2)
-                @test length(t) == 1
-                @test nsamples(t[1]) == 6
-                @test trace(t[1]) == [1, 2, 3, 4, 5, 6]
-                @test channel_code(t[1]) == "AN.STA2..HHZ"
+                @testset "Single segment from larger gap" begin
+                    t = read_mseed(path, maximum_gap=2)
+                    @test length(t) == 1
+                    @test nsamples(t[1]) == 6
+                    @test trace(t[1]) == [1, 2, 3, 4, 5, 6]
+                    @test channel_code(t[1]) == "AN.STA2..HHZ"
+                end
+            else
+                @test_throws ErrorException read_mseed(path, maximum_gap=0)
             end
         end
 


### PR DESCRIPTION
Add a macOS runner to the GitHub Actions CI script so that we can test
on an ARM platform.

Because it's not supported on ARM (or PowerPC), changing the allowed
`maximum_gap` in `read_mseed` is properly tested to throw an error if
that keyword argument is set.
