### PR TITLE
Add keyword argument constructors for Traces

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -63,6 +63,8 @@
 - A one-sided (or no-sided) taper can be applied using the new keywords
   arguments to `taper[!]` `left` and `right`.
 - One-sided tapers can be applied to up to 100% of the trace length.
+- Trace constructors like `Trace` now have keyword argument versions and
+  defaults for `b` and `delta`.
 ### Plotting with [Makie.jl](https://docs.makie.org/stable)
 - If you are on Julia v1.9 or greater and have loaded
   the `Makie` package (e.g., via one of its backends like `using GLMakie`),

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -57,7 +57,7 @@ composite types:
 
 ```@repl example
 # A trace starting a 0 s with sampling interval 1 s made of 100 random samples
-t = Trace(0, 1, rand(100))
+t = Trace(b=0, delta=1, data=rand(100))
 # Update the sampling interval to 0.1 s
 t.delta = 0.1
 ```


### PR DESCRIPTION
Allow `Trace`s to be created with keyword arguments rather than
only positional arguments, and define defaults for the begin time,
sampling interval and trace content.

With `Trace`, `CartTrace` and `GeogTrace`, type parameters can be
specified as usual with the keyword argument constructors as well
as with the positional argument versions.
