### PR TITLE
Fix bug in cutting with dates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -77,5 +77,7 @@
   `are_orthogonal` which works for non-horizontal pairs as well.
 
 ## Notable bug fixes
+- `cut[!]` using dates only worked correctly when the trace start time was 0;
+  this has been fixed.
 - `rotate_through[!]` behaved in an inconsistent way and has been fixed
   (see 'Breaking changes'), but its new behaviour is different.

--- a/src/operations.jl
+++ b/src/operations.jl
@@ -181,8 +181,8 @@ end
 
 function _cut_time_indices(t::AbstractTrace, b::DateTime, e::DateTime; warn=true, allowempty=true)
     t.evt.time === missing && throw(ArgumentError("no event time defined for trace array"))
-    b_ms::Dates.Millisecond = b - startdate(t)
-    e_ms::Dates.Millisecond = e - startdate(t)
+    b_ms::Dates.Millisecond = b - origin_time(t)
+    e_ms::Dates.Millisecond = e - origin_time(t)
     b = Dates.value(b_ms)/1000
     e = Dates.value(e_ms)/1000
     _cut_time_indices(t, b, e; warn, allowempty)

--- a/test/operations.jl
+++ b/test/operations.jl
@@ -51,6 +51,45 @@ end
                 @test enddate(t′) == time_now + Second(1)
             end
 
+            @testset "Dates with non-zero b" begin
+                t2 = Trace(0.5, 1, 1:20)
+                origin_time!(t2, DateTime(2000))
+
+                @testset "Relative" begin
+                    cut1 = 1.1
+                    cut2 = 2.9
+                    t_cut = cut(t2, cut1, cut2; warn=false)
+                    @test nsamples(t_cut) == 2
+                    @test times(t_cut) == 1.5:1.0:2.5
+                    @test all(
+                        dates(t_cut) .== DateTime.(2000, 1, 1, 0, 0, (1, 2), 500)
+                    )
+                    @test trace(t_cut) == trace(t2)[2:3]
+
+                    @testset "In-place" begin
+                        @test cut!(deepcopy(t2), cut1, cut2; warn=false) == t_cut
+                    end
+                end
+
+                @testset "Date" begin
+                    d1 = DateTime(2000, 1, 1, 0, 0, 1, 100)
+                    d2 = DateTime(2000, 1, 1, 0, 0, 2, 900)
+                    t_cut = cut(t2, d1, d2)
+
+                    @test nsamples(t_cut) == 2
+                    @test times(t_cut) == 1.5:1.0:2.5
+                    @test all(
+                        dates(t_cut) .== DateTime.(2000, 1, 1, 0, 0, (1, 2), 500)
+                    )
+                    @test trace(t_cut) == trace(t2)[2:3]
+
+                    @testset "In-place" begin
+                        @test cut!(deepcopy(t2), d1, d2; warn=false) == t_cut
+                    end
+                end
+
+            end
+
             @testset "Picks" begin
                 add_pick!(t, 1, "Test pick")
                 @test cut(t, "Test pick", 0, "Test pick", 0.5) == cut(t, 1, 1.5)


### PR DESCRIPTION
Previously the cut window was incorrectly calculated if specified with
dates rather than times, unless the trace start time (`b`) was 0.  Fix
this and add more rigorous test cases.
