### PR TITLE
plot_section: Fix error when only one pick exists in all traces

### DIFF
--- a/ext/SeisMakieExt.jl
+++ b/ext/SeisMakieExt.jl
@@ -483,6 +483,9 @@ function Seis.plot_section!(
                 for (tt, y, t_shift) in zip(ts, y_shifts, shifts)
                 for (key, (time, name)) in tt.picks)
         )
+        # If there is only one pick, then `reduce(vcat, ...)` does not return a vector:
+        # https://github.com/JuliaLang/julia/issues/34380
+        picks = (picks isa AbstractArray) ? picks : [picks]
         picks_t = first.(picks)
         picks_y = getindex.(picks, 2)
         picks_text = last.(picks)


### PR DESCRIPTION
When using `show_picks=true` with `plot_section`, previously an error
would occur if exactly one pick existed across all traces, because
`reduce(vcat, [v])` returns `v` not `[v]` (i.e., when there is only one
element over which the reduction happens).  Fix this by checking whether
an `AbstractArray` is returned.
