### PR TITLE
Use elevation not depth for Geographic and fix STEL IO for SAC files

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -81,3 +81,9 @@
   this has been fixed.
 - `rotate_through[!]` behaved in an inconsistent way and has been fixed
   (see 'Breaking changes'), but its new behaviour is different.
+
+## Internal changes
+- The `Seis.Geographic` internal type now stores elevation rather than depth.
+  External code which used this type directly may need to update any positional
+  argument constructors which relied on the third argument being depth (km)
+  rather than elevation (m).

--- a/src/conversion.jl
+++ b/src/conversion.jl
@@ -14,11 +14,14 @@ for Geom in (Cartesian, Geographic)
             $geom{Tout}($([:(getfield(p, $i)) for i in 1:fieldcount(Geom)]...))
 
         Base.convert(::Type{Event{Tout,$geom{Tout}}}, e::Event{Tin,$geom{Tin}}) where {Tin, Tout} =
-            Event{Tout,$geom{Tout}}(e.pos, e.time, e.id, e.meta)
+            Event{Tout,$geom{Tout}}(
+                $([:(getfield(e, $i)) for i in 1:fieldcount(Event)]...)
+            )
 
         Base.convert(::Type{Station{Tout,$geom{Tout}}}, s::Station{Tin,$geom{Tin}}) where {Tin, Tout} =
-            Station{Tout,$geom{Tout}}(s.net, s.sta, s.loc, s.cha, s.pos, s.elev,
-                s.azi, s.inc, s.meta)
+            Station{Tout,$geom{Tout}}(
+                $([:(getfield(s, $i)) for i in 1:fieldcount(Station)]...)
+            )
 
         Base.convert(::Type{Trace{T,V,$geom{T}}}, t::Trace{T,V,$geom{T}}) where {T,V} = t
         function Base.convert(::Type{Trace{Tout,Vout,$geom{Tout}}},

--- a/src/input_output.jl
+++ b/src/input_output.jl
@@ -157,10 +157,9 @@ function Trace(s::SAC.SACTrace; header_only=false)
     end
 
     # Station and component
-    for (sacfield, tfield) in (:stlo=>:lon, :stla=>:lat)
+    for (sacfield, tfield) in (:stlo=>:lon, :stla=>:lat, :stel=>:elev)
         setproperty!(t.sta, tfield, _sacmissing(s[sacfield]))
     end
-    !SAC.isundefined(s, :stel) && (t.sta.pos.dep = -s[:stel]/1000)
     for (sacfield, tfield) in (:kstnm=>:sta, :knetwk=>:net, :khole=>:loc,
                                :kcmpnm=>:cha, :cmpaz=>:azi, :cmpinc=>:inc)
         setproperty!(t.sta, tfield, _sacmissing(s[sacfield]))
@@ -185,7 +184,7 @@ function Trace(s::SAC.SACTrace; header_only=false)
 
         sacfield in sac_hdr && continue
         SAC.isundefined(s, sacfield) && continue
-        metafield = Symbol("SAC_" * String(sacfield))
+        metafield = Symbol("SAC_", sacfield)
         t.meta[metafield] = s[sacfield]
     end
     t

--- a/test/io.jl
+++ b/test/io.jl
@@ -1,3 +1,4 @@
+using Dates: DateTime
 using Test
 using Seis
 import Seis.SAC
@@ -13,6 +14,15 @@ import Seis.SAC
             @test t.t == s.t
             @test t.evt.id == "K8108838"
             @test t.sta.sta == "CDV"
+            @test t.sta.azi == 0
+            @test t.sta.inc == 0
+            @test t.sta.lat == 48
+            @test t.sta.lon == -120
+            @test t.sta.elev === missing
+            @test t.evt.lat == 48
+            @test t.evt.lon == -125
+            @test t.evt.dep == 0
+            @test t.evt.time == DateTime("1981-03-29T10:38:14.000")
             @test t.meta.SAC_lpspol   == true
             @test t.meta.SAC_nevid    == 0
             @test t.meta.SAC_iftype   == 1
@@ -160,6 +170,11 @@ import Seis.SAC
                     end
                 end
             end
+        end
+
+        @testset "Station elevation" begin
+            t = sample_data(:local)[1]
+            @test t.sta.elev == 265.0
         end
 
         # Removing null bytes from strings on read


### PR DESCRIPTION
Previously, the `Geographic <: Position` type had the field `dep` for
storing the vertical position of something in terms of its depth below
the reference level in km.  However, we dealt with this in an ad-hoc
way between `GeogEvent`s and `GeogStation`s, which both hold a
`Geographic` position as a field, because depth is more natural for an
event, but elevation is more natural for a station.  This meant that it
was necessary to convert between elevation and depth when constructing
stations.

Replace this ad-hoc approach by implementing automatic conversion
between elevation (in m) and depth (in km) via `getproperty` and
`setproperty!`, allowing access for both `.elev` and `.dep` fields for
`Geographic` objects.  `.elev` becomes the true field, which further
gives a sort of local right-handed coordinate system 'lon-lat-up'.

To make this more seamless, `propertynames` now lists `dep` for `Event`s
but `elev` for `Station`s, which simplifies the `show` methods.

Other changes along the way:
- Fix header name length calculation in `show`
- Improve docstrings for `Geographic` and `Cartesian`
- Test station elevation reading/writing for SAC files
