### PR TITLE
Fix broken delta calculation in ifft for odd number of samples

### DIFF
--- a/src/spec.jl
+++ b/src/spec.jl
@@ -318,7 +318,7 @@ function ifft(f::FourierTrace{T,<:AbstractVector{<:Complex{TV}},P},
     # is no method to construct a `FFTW.FakeArray`.
     data = FFTW.irfft(trace(f), Int(n)).*scale
 
-    delta = 1/(2*(nfrequencies(f) - 1)*f.delta)
+    delta = 1/(n*f.delta)
     Trace{T,Vector{TV},P}(f.b, delta, data, f.evt, f.sta, f.picks, f.meta)
 end
 

--- a/test/spec.jl
+++ b/test/spec.jl
@@ -24,13 +24,23 @@ using Test
             end
         end
 
-        @testset "Round-trip" begin
-            for p in propertynames(t)
-                v, v′ = getfield.((t, t′), p)
-                if p == :t
-                    @test v ≈ v′
-                else
-                    @test isequal(v, v′)
+        @testset "nsamples $odd_even" for odd_even in (:odd, :even)
+            t2, t2′ = if odd_even == :odd
+                t2 = deepcopy(t)
+                pop!(trace(t2))
+                t2, ifft(fft(t2))
+            else
+                t, t′
+            end
+
+            @testset "Round-trip" begin
+                for p in propertynames(t2)
+                    v, v′ = getfield.((t2, t2′), p)
+                    if p == :t
+                        @test v ≈ v′
+                    else
+                        @test isequal(v, v′)
+                    end
                 end
             end
         end


### PR DESCRIPTION
Previously, an incorrect value for `delta` was computed in `ifft` when
a trace originally had an odd number of samples.  Fix this and test for
this case.
