### PR TITLE
Docs: Add references to write_stationxml

### DIFF
--- a/docs/src/function-index.md
+++ b/docs/src/function-index.md
@@ -124,6 +124,7 @@ parse_stationxml
 write_mseed
 write_sac
 write_sac_header
+write_stationxml
 Seis.SAC.SACTrace
 ```
 

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -330,6 +330,11 @@ Seis supports reading and writing only the header part of SAC files:
 miniSEED files can be read with only headers using
 `read_mseed(file; header_only=true)`.
 
+### Station metadata
+
+Sets of `Station`s can have their metadata written out in StationXML format
+using [`write_stationxml`](@ref).
+
 
 ## Basic processing
 


### PR DESCRIPTION
Add missing reference to `write_stationxml` and add the docstring
to the function index.
