### PR TITLE
Add channel_code_parts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -69,6 +69,8 @@
 - One-sided tapers can be applied to up to 100% of the trace length.
 - Trace constructors like `Trace` now have keyword argument versions and
   defaults for `b` and `delta`.
+- `channel_code_parts` returns the individual channel code elements (net,
+  sta, loc, cha) from a string, `Station` or `Trace`.
 ### Plotting with [Makie.jl](https://docs.makie.org/stable)
 - If you are on Julia v1.9 or greater and have loaded
   the `Makie` package (e.g., via one of its backends like `using GLMakie`),

--- a/docs/src/function-index.md
+++ b/docs/src/function-index.md
@@ -18,6 +18,7 @@ CartStation
 ```@docs
 are_orthogonal
 channel_code
+channel_code_parts
 dates
 enddate
 endtime

--- a/docs/src/manual.md
+++ b/docs/src/manual.md
@@ -115,6 +115,9 @@ They have the following fields which you can access and modify:
   station, channel and location names of a single recording channel.
   They correspond to the
   [SEED channel naming convention](http://www.fdsn.org/pdf/SEEDManual_V2.4_Appendix-A.pdf), but all can be `missing`.
+  Use [`channel_code`](@ref) to get a SEED-style "net.sta.loc.cha"
+  string from a `Station`, or get a named tuple with these parts
+  using [`channel_code_parts`](@ref), from a string or `Station`.
 - `lon`, `lat` and `elev` are the longitude and latitude (in °, positive
   eastwards and northwards) of the station, whilst `elev` is the elevation
   above sea level in m.

--- a/src/Seis.jl
+++ b/src/Seis.jl
@@ -110,6 +110,7 @@ export
     # IO
     SACtr,
     channel_code,
+    channel_code_parts,
     parse_stationxml,
     read_mseed,
     read_sac,

--- a/src/input_output.jl
+++ b/src/input_output.jl
@@ -533,11 +533,95 @@ Return the channel code for trace `t` or station `s`, in the form of
 `"⟨network⟩.⟨name⟩.⟨location⟩.⟨component⟩"`.  Missing fields are left blank.
 The information is taken respectively from the `net`, `sta`, `cha` and `loc`
 fields of the `Station`.
+
+# Example
+```
+julia> channel_code(sample_data())
+".CDV.."
+```
+
+See also: [`channel_code_parts`](@ref)
 """
 channel_code(sta::Station) = join(map(_blankmissing, (sta.net, sta.sta, sta.loc, sta.cha)), ".")
 channel_code(t::AbstractTrace) = channel_code(t.sta)
 
 _blankmissing(x) = string(ismissing(x) ? "" : x)
+
+"""
+    channel_code_parts(s::AbstractString) -> (; net, sta, loc, cha)
+    channel_code_parts(sta::Station) -> (; net, sta, loc, cha)
+    channel_code_parts(t::Trace) -> (; net, sta, loc, cha)
+
+Return the channel code parts for trace `t`, station `sta` or string `s`
+as a named tuple with keys `:net`, `:sta`, `:loc` and `:cha`.  The values
+of the named tuple contain the string parts and are empty strings if any
+of the fields are `missing` in `sta` or `t`.
+
+# Example
+```
+julia> channel_code_parts("XX.AN..GPZ")
+(net = "XX", sta = "AN", loc = "", cha = "GPZ")
+
+julia> channel_code_parts(Station(sta="ABC", cha="Z"))
+(net = "", sta = "ABC", loc = "", cha = "Z")
+```
+
+See also: [`channel_code`](@ref)
+"""
+function channel_code_parts(s::AbstractString)
+    if count(c -> c === '.', s) != 3
+        throw(ArgumentError("channel code string must have three '.' characters"))
+    end
+
+    net, i = _string_to_next_dot(s)
+    sta, i = _string_to_next_dot(s, i)
+    loc, i = _string_to_next_dot(s, i)
+    cha, i = _string_to_next_dot(s, i)
+    if i != lastindex(s)
+        error("error in logic")
+    end
+
+    (; net, sta, loc, cha)
+end
+channel_code_parts(sta::Station) = (;
+    net=_blankmissing(sta.net),
+    sta=_blankmissing(sta.sta),
+    loc=_blankmissing(sta.loc),
+    cha=_blankmissing(sta.cha),
+)
+channel_code_parts(t::Trace) = channel_code_parts(t.sta)
+
+"""
+    _string_to_next_dot(s, i=prevind(s, 1)) -> substr, j
+
+Return the substring of `s` which starts at index `i+1` and continues up until
+but not including the next `'.'` character if present, or the end of the
+string; and also return the index to the next dot character `j`, or
+`nothing` if this is the last substring in `s`.
+
+# Example
+```
+julia> _string_to_next_dot("ABC.DEF.", 1)
+"ABC", 4
+
+julia> _string_to_next_dot("ABC.DEF.", 4)
+"DEF", 8
+
+julia> _string_to_next_dot("ABC.DEF.", 8)
+"", 8
+```
+"""
+function _string_to_next_dot(s, i=prevind(s, 1))
+    j = i
+    while j < lastindex(s)
+        j = nextind(s, j)
+        if s[j] == '.'
+            return s[nextind(s, i):prevind(s, j)], j
+        end
+    end
+    s[nextind(s, i):j], j
+end
+
 
 #
 # StationXML

--- a/test/io.jl
+++ b/test/io.jl
@@ -233,4 +233,39 @@ import Seis.SAC
             @test channel_code(t) == "..GH.IJK"
         end
     end
+
+    @testset "Channel code parts" begin
+        @testset "Strings" begin
+            strs = ("", "A", "ABC", "D″", "ßöø€")
+
+            @testset "Wrong input" begin
+                @test_throws ArgumentError channel_code_parts("XX.ABC.XYZ")
+                @test_throws ArgumentError channel_code_parts("XX.ABC")
+                @test_throws ArgumentError channel_code_parts("XX")
+                @test_throws ArgumentError channel_code_parts("")
+                @test_throws ArgumentError channel_code_parts("1.2.3.4.")
+                @test_throws ArgumentError channel_code_parts(".1.2.3.4")
+            end
+
+            @testset "Correct input" begin                
+                for net in strs, sta in strs, loc in strs, cha in strs
+                    @test channel_code_parts("$net.$sta.$loc.$cha") == (; net, sta, loc, cha)
+                end
+            end
+        end
+
+        @testset "Station and Trace" begin
+            strs = ("", missing, "ABC", "D″", "ßöø€")
+            _bm = x -> ismissing(x) ? "" : x
+
+            for net in strs, sta in strs, loc in strs, cha in strs
+                @test channel_code_parts(
+                    Station(; net, sta, loc, cha)
+                ) == (; net=_bm(net), sta=_bm(sta), loc=_bm(loc), cha=_bm(cha))
+                @test channel_code_parts(
+                    Trace(; b=0, delta=1, data=[], sta=Station(; net, sta, loc, cha))
+                ) == (; net=_bm(net), sta=_bm(sta), loc=_bm(loc), cha=_bm(cha))
+            end
+        end
+    end
 end


### PR DESCRIPTION
`channel_code_parts` returns the individual network, station, location
and channel parts of a string, or the codes from a `Station` object (or
`Trace`).
