### PR TITLE
CI: Fix issue of trying to run x64 on macos-latest

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,6 @@ jobs:
         os:
           - ubuntu-latest
           - windows-latest
-          - macos-latest
         arch:
           - x64
         include:
@@ -32,9 +31,12 @@ jobs:
           - os: ubuntu-latest
             version: '1'
             arch: x86
-          - os: macos-14
+          - os: macos-latest
             version: '1'
-            arch: arm64
+            arch: aarch64
+          - os: macos-latest
+            version: 'nightly'
+            arch: aarch64
     steps:
       - uses: actions/checkout@v6
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
macOS runners on GitHub Actions are of course now aarch64 in terms
of architecture, but we had not updated CI to recognise this.
